### PR TITLE
Fix Runbook add-devices-of-users-to-group_scheduled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # RealmJoin Runbooks Changelog
 
+## 2025-02-12
+- Fix: add-devices-of-users-to-group_scheduled - add AndroidForWork condition
+
 ## 2025-02-11
 - New Runbook: Group/General/List all members - list members of a specified EntraID group, including members from nested groups.
 

--- a/org/general/add-devices-of-users-to-group_scheduled.ps1
+++ b/org/general/add-devices-of-users-to-group_scheduled.ps1
@@ -57,7 +57,7 @@ param(
 
 Write-RjRbLog -Message "Caller: '$CallerName'" -Verbose
 
-$Version = "1.0.0"
+$Version = "1.0.1"
 Write-RjRbLog -Message "Version: $Version" -Verbose
 
 # Log the selected OS options

--- a/org/general/add-devices-of-users-to-group_scheduled.ps1
+++ b/org/general/add-devices-of-users-to-group_scheduled.ps1
@@ -133,7 +133,8 @@ foreach ($User in $UserGroupMembers) {
         ($IncludeWindowsDevice -and $_.operatingSystem -eq "Windows" -and $_.trustType -eq "AzureAd") -or 
         ($IncludeMacOSDevice -and $_.operatingSystem -eq "MacMDM") -or 
         ($IncludeLinuxDevice -and $_.operatingSystem -eq "Linux") -or 
-        ($IncludeAndroidDevice -and $_.operatingSystem -eq "Android") -or 
+        ($IncludeAndroidDevice -and $_.operatingSystem -eq "Android") -or
+        ($IncludeAndroidDevice -and $_.operatingSystem -eq "AndroidForWork") -or 
         ($IncludeIOSDevice -and ($_.operatingSystem -eq "iOS" -or $_.operatingSystem -eq "IPhone")) -or
         ($IncludeIPadOSDevice -and ($_.operatingSystem -eq "iPadOS" -or $_.operatingSystem -eq "IPad"))
     }


### PR DESCRIPTION
This pull request includes a fix and an update to the `add-devices-of-users-to-group_scheduled` script. The most important changes are the addition of a condition for AndroidForWork devices and the version update in the script. Additionally, the changelog has been updated to reflect these changes.

Change was contributed by @OliWei31
GitLab Issue 125

Fixes and updates:

* [`org/general/add-devices-of-users-to-group_scheduled.ps1`](diffhunk://#diff-9eef916b1d656dc9859c787a94e9a3d7c8966715d5740a6baffd5223aac36242R137): Added a condition to include AndroidForWork devices in the script.
* [`org/general/add-devices-of-users-to-group_scheduled.ps1`](diffhunk://#diff-9eef916b1d656dc9859c787a94e9a3d7c8966715d5740a6baffd5223aac36242L60-R60): Updated the version from `1.0.0` to `1.0.1`.

Changelog update:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R5): Added an entry for February 12, 2025, detailing the fix for adding AndroidForWork condition in the script.