### PR TITLE
Fix Runbook add-devices-of-users-to-group_scheduled (#180)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # RealmJoin Runbooks Changelog
 
+## 2025-02-12
+- Fix: add-devices-of-users-to-group_scheduled - add AndroidForWork condition
+
 ## 2025-02-11
 - New Runbook: Group/General/List all members - list members of a specified EntraID group, including members from nested groups.
 

--- a/org/general/add-devices-of-users-to-group_scheduled.ps1
+++ b/org/general/add-devices-of-users-to-group_scheduled.ps1
@@ -57,7 +57,7 @@ param(
 
 Write-RjRbLog -Message "Caller: '$CallerName'" -Verbose
 
-$Version = "1.0.0"
+$Version = "1.0.1"
 Write-RjRbLog -Message "Version: $Version" -Verbose
 
 # Log the selected OS options
@@ -133,7 +133,8 @@ foreach ($User in $UserGroupMembers) {
         ($IncludeWindowsDevice -and $_.operatingSystem -eq "Windows" -and $_.trustType -eq "AzureAd") -or 
         ($IncludeMacOSDevice -and $_.operatingSystem -eq "MacMDM") -or 
         ($IncludeLinuxDevice -and $_.operatingSystem -eq "Linux") -or 
-        ($IncludeAndroidDevice -and $_.operatingSystem -eq "Android") -or 
+        ($IncludeAndroidDevice -and $_.operatingSystem -eq "Android") -or
+        ($IncludeAndroidDevice -and $_.operatingSystem -eq "AndroidForWork") -or 
         ($IncludeIOSDevice -and ($_.operatingSystem -eq "iOS" -or $_.operatingSystem -eq "IPhone")) -or
         ($IncludeIPadOSDevice -and ($_.operatingSystem -eq "iPadOS" -or $_.operatingSystem -eq "IPad"))
     }


### PR DESCRIPTION
* Add support for Android for Work devices in device inclusion logic

* Bump version to 1.0.1 in add-devices-of-users-to-group scheduled script

* Fix: add AndroidForWork condition in add-devices-of-users-to-group scheduled script