### PR TITLE
Phone runbooks: add permission notes, update modules, remove outdated connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # RealmJoin Runbooks Changelog
 
+## 2025-02-24
+- Update all phone related runbooks:
+  - Teams PowerShell module updated to 6.8.0
+  - Add Permissions in .Notes section
+  - Remove outdated service user (credential) based connection 
+  - Update version number
+
 ## 2025-02-19
 - New Runbook: Org/Phone/Get Teams Phone Number Assignment - Get the phone number assignment of the specified phone number and output the user if assigned
 

--- a/org/phone/get-teams-phonenumber-assignment.ps1
+++ b/org/phone/get-teams-phonenumber-assignment.ps1
@@ -46,19 +46,17 @@ param(
 ##          
 ########################################################
 
-# Add Caller in Verbose output
+# Add Caller and Version in Verbose output
 if ($CallerName) {
     Write-RjRbLog -Message "Caller: '$CallerName'" -Verbose
 }
 
-# Add Version in Verbose output
 $Version = "1.0.0"
 Write-RjRbLog -Message "Version: $Version" -Verbose
 
 # Add Parameter in Verbose output
 Write-RjRbLog -Message "Submitted parameters:" -Verbose
 Write-RjRbLog -Message "PhoneNumber: $PhoneNumber" -Verbose
-
 
 #endregion
 

--- a/user/phone/disable-teams-phone.ps1
+++ b/user/phone/disable-teams-phone.ps1
@@ -37,57 +37,53 @@ param(
     [string] $CallerName
 )
 
-# Add Caller in Verbose output
+########################################################
+#region     RJ Log Part
+##          
+########################################################
+
+# Add Caller and Version in Verbose output
 if ($CallerName) {
     Write-RjRbLog -Message "Caller: '$CallerName'" -Verbose
 }
 
-# Add Version in Verbose output
-$Version = "1.0.0" 
+$Version = "1.0.1"
 Write-RjRbLog -Message "Version: $Version" -Verbose
+Write-RjRbLog -Message "Submitted parameters:" -Verbose
+Write-RjRbLog -Message "UserName: $UserName" -Verbose
+
+#endregion
 
 ########################################################
-##             Connect Part
+#region     Connect Part
 ##          
 ########################################################
-# Needs a Microsoft Teams Connection First!
 
-Write-Output "Connection - Connect to Microsoft Teams (PowerShell)"
+Write-Output "Connect to Microsoft Teams..."
 
 try {
-    $CredAutomation = Get-AutomationPSCredential -Name 'teamsautomation'
+    $VerbosePreference = "SilentlyContinue"
+    $tmp = Connect-MicrosoftTeams -Identity -ErrorAction Stop
+    $VerbosePreference = "Continue"
+    # Check if Teams connection is active
+    Get-CsTenant -ErrorAction Stop | Out-Null
 }
 catch {
-    Write-Output "Connection - No automation credentials "teamsautomation" stored. Try newer managed identity approach now"
-}
-
-if ($CredAutomation -notlike "") {
-    $VerbosePreference = "SilentlyContinue"
-    Connect-MicrosoftTeams -Credential $CredAutomation 
-    $VerbosePreference = "Continue"
-}
-else {
-    Write-Output "Connection - Connect as RealmJoin managed identity"
-    $VerbosePreference = "SilentlyContinue"
-    Connect-MicrosoftTeams -Identity -ErrorAction Stop
-    $VerbosePreference = "Continue"
-}
-
-# Check if Teams connection is active
-try {
-    $Test = Get-CsTenant -ErrorAction Stop | Out-Null
-}
-catch {
-    try {        
-        Start-Sleep -Seconds 5
-        Write-Output "2nd try after five seconds"
-        $Test = Get-CsTenant -ErrorAction Stop | Out-Null
+    Start-Sleep -Seconds 5
+    try {
+        $VerbosePreference = "SilentlyContinue"
+        $tmp = Connect-MicrosoftTeams -Identity -ErrorAction Stop
+        $VerbosePreference = "Continue"
+        # Check if Teams connection is active
+        Get-CsTenant -ErrorAction Stop | Out-Null
     }
-    catch {        
-        Write-Warning "Teams PowerShell session could not be established. Stopping script!" 
+    catch {
+        Write-Error "Microsoft Teams PowerShell session could not be established. Stopping script!" 
         Exit
     }
 }
+
+#endregion
 
 ########################################################
 ##             Get StatusQuo

--- a/user/phone/get-teams-user-info.ps1
+++ b/user/phone/get-teams-user-info.ps1
@@ -42,15 +42,18 @@ param(
 ##          
 ########################################################
 
-# Add Caller in Verbose output
+# Add Caller and Version in Verbose output
 if ($CallerName) {
     Write-RjRbLog -Message "Caller: '$CallerName'" -Verbose
 }
 
 $Version = "1.0.1"
 Write-RjRbLog -Message "Version: $Version" -Verbose
+Write-RjRbLog -Message "Submitted parameters:" -Verbose
+Write-RjRbLog -Message "UserName: $UserName" -Verbose
 
 #endregion
+
 ########################################################
 #region     Connect Part
 ##          

--- a/user/phone/grant-teams-user-policies.ps1
+++ b/user/phone/grant-teams-user-policies.ps1
@@ -64,57 +64,61 @@ param(
     [Parameter(Mandatory = $true)]
     [string] $CallerName
 )
-# Add Caller in Verbose output
+
+########################################################
+#region     RJ Log Part
+##          
+########################################################
+
+# Add Caller and Version in Verbose output
 if ($CallerName) {
     Write-RjRbLog -Message "Caller: '$CallerName'" -Verbose
 }
 
-# Add Version in Verbose output
-$Version = "1.0.0" 
+$Version = "1.0.1"
 Write-RjRbLog -Message "Version: $Version" -Verbose
+Write-RjRbLog -Message "Submitted parameters:" -Verbose
+Write-RjRbLog -Message "UserName: $UserName" -Verbose
+Write-RjRbLog -Message "OnlineVoiceRoutingPolicy: $OnlineVoiceRoutingPolicy" -Verbose
+Write-RjRbLog -Message "TenantDialPlan: $TenantDialPlan" -Verbose
+Write-RjRbLog -Message "TeamsCallingPolicy: $TeamsCallingPolicy" -Verbose
+Write-RjRbLog -Message "TeamsIPPhonePolicy: $TeamsIPPhonePolicy" -Verbose
+Write-RjRbLog -Message "OnlineVoicemailPolicy: $OnlineVoicemailPolicy" -Verbose
+Write-RjRbLog -Message "TeamsMeetingPolicy: $TeamsMeetingPolicy" -Verbose
+Write-RjRbLog -Message "TeamsMeetingBroadcastPolicy: $TeamsMeetingBroadcastPolicy" -Verbose
+
+#endregion
 
 ########################################################
-##             Connect Part
+#region     Connect Part
 ##          
 ########################################################
-# Needs a Microsoft Teams Connection First!
 
-Write-Output "Connection - Connect to Microsoft Teams (PowerShell)"
+Write-Output "Connect to Microsoft Teams..."
 
 try {
-    $CredAutomation = Get-AutomationPSCredential -Name 'teamsautomation'
+    $VerbosePreference = "SilentlyContinue"
+    $tmp = Connect-MicrosoftTeams -Identity -ErrorAction Stop
+    $VerbosePreference = "Continue"
+    # Check if Teams connection is active
+    Get-CsTenant -ErrorAction Stop | Out-Null
 }
 catch {
-    Write-Output "Connection - No automation credentials "teamsautomation" stored. Try newer managed identity approach now"
-}
-
-if ($CredAutomation -notlike "") {
-    $VerbosePreference = "SilentlyContinue"
-    Connect-MicrosoftTeams -Credential $CredAutomation 
-    $VerbosePreference = "Continue"
-}
-else {
-    Write-Output "Connection - Connect as RealmJoin managed identity"
-    $VerbosePreference = "SilentlyContinue"
-    Connect-MicrosoftTeams -Identity -ErrorAction Stop
-    $VerbosePreference = "Continue"
-}
-
-# Check if Teams connection is active
-try {
-    $Test = Get-CsTenant -ErrorAction Stop | Out-Null
-}
-catch {
+    Start-Sleep -Seconds 5
     try {
-        Start-Sleep -Seconds 5
-        $Test = Get-CsTenant -ErrorAction Stop | Out-Null
+        $VerbosePreference = "SilentlyContinue"
+        $tmp = Connect-MicrosoftTeams -Identity -ErrorAction Stop
+        $VerbosePreference = "Continue"
+        # Check if Teams connection is active
+        Get-CsTenant -ErrorAction Stop | Out-Null
     }
-    catch {        
-        Write-Error -Message "Teams PowerShell session could not be established. Stopping script!" -ErrorAction Continue
-        throw "Teams PowerShell session could not be established. Stopping script!"
+    catch {
+        Write-Error "Microsoft Teams PowerShell session could not be established. Stopping script!" 
         Exit
     }
 }
+
+#endregion
 
 ########################################################
 ##             StatusQuo & Preflight-Check Part

--- a/user/phone/set-teams-permanent-call-forwarding.ps1
+++ b/user/phone/set-teams-permanent-call-forwarding.ps1
@@ -161,57 +161,58 @@ param(
     [string] $CallerName
 )
 
-# Add Caller in Verbose output
+########################################################
+#region     RJ Log Part
+##          
+########################################################
+
+# Add Caller and Version in Verbose output
 if ($CallerName) {
     Write-RjRbLog -Message "Caller: '$CallerName'" -Verbose
 }
 
-# Add Version in Verbose output
-$Version = "1.0.0" 
+$Version = "1.0.1"
 Write-RjRbLog -Message "Version: $Version" -Verbose
+Write-RjRbLog -Message "Submitted parameters:" -Verbose
+Write-RjRbLog -Message "UserName: $UserName" -Verbose
+Write-RjRbLog -Message "ForwardTargetPhoneNumber: $ForwardTargetPhoneNumber" -Verbose
+Write-RjRbLog -Message "ForwardTargetTeamsUser: $ForwardTargetTeamsUser" -Verbose
+Write-RjRbLog -Message "ForwardToVoicemail: $ForwardToVoicemail" -Verbose
+Write-RjRbLog -Message "ForwardToDelegates: $ForwardToDelegates" -Verbose
+Write-RjRbLog -Message "TurnOffForward: $TurnOffForward" -Verbose
+
+#endregion
 
 ########################################################
-##             Connect Part
+#region     Connect Part
 ##          
 ########################################################
-# Needs a Microsoft Teams Connection First!
 
-Write-Output "Connection - Connect to Microsoft Teams (PowerShell)"
+Write-Output "Connect to Microsoft Teams..."
 
 try {
-    $CredAutomation = Get-AutomationPSCredential -Name 'teamsautomation'
+    $VerbosePreference = "SilentlyContinue"
+    $tmp = Connect-MicrosoftTeams -Identity -ErrorAction Stop
+    $VerbosePreference = "Continue"
+    # Check if Teams connection is active
+    Get-CsTenant -ErrorAction Stop | Out-Null
 }
 catch {
-    Write-Output "Connection - No automation credentials "teamsautomation" stored. Try newer managed identity approach now"
-}
-
-if ($CredAutomation -notlike "") {
-    $VerbosePreference = "SilentlyContinue"
-    Connect-MicrosoftTeams -Credential $CredAutomation 
-    $VerbosePreference = "Continue"
-}
-else {
-    Write-Output "Connection - Connect as RealmJoin managed identity"
-    $VerbosePreference = "SilentlyContinue"
-    Connect-MicrosoftTeams -Identity -ErrorAction Stop
-    $VerbosePreference = "Continue"
-}
-
-# Check if Teams connection is active
-try {
-    $Test = Get-CsTenant -ErrorAction Stop | Out-Null
-}
-catch {
+    Start-Sleep -Seconds 5
     try {
-        Start-Sleep -Seconds 5
-        $Test = Get-CsTenant -ErrorAction Stop | Out-Null
+        $VerbosePreference = "SilentlyContinue"
+        $tmp = Connect-MicrosoftTeams -Identity -ErrorAction Stop
+        $VerbosePreference = "Continue"
+        # Check if Teams connection is active
+        Get-CsTenant -ErrorAction Stop | Out-Null
     }
-    catch {        
-        Write-Error -Message "Teams PowerShell session could not be established. Stopping script!" -ErrorAction Continue
-        throw "Teams PowerShell session could not be established. Stopping script!"
+    catch {
+        Write-Error "Microsoft Teams PowerShell session could not be established. Stopping script!" 
         Exit
     }
 }
+
+#endregion
 
 ########################################################
 ##             StatusQuo & Preflight-Check Part

--- a/user/phone/set-teams-phone.ps1
+++ b/user/phone/set-teams-phone.ps1
@@ -68,57 +68,58 @@ param(
     [string] $CallerName
 )
 
-# Add Caller in Verbose output
+########################################################
+#region     RJ Log Part
+##          
+########################################################
+
+# Add Caller and Version in Verbose output
 if ($CallerName) {
     Write-RjRbLog -Message "Caller: '$CallerName'" -Verbose
 }
 
-# Add Version in Verbose output
-$Version = "1.0.0" 
+$Version = "1.0.1"
 Write-RjRbLog -Message "Version: $Version" -Verbose
+Write-RjRbLog -Message "Submitted parameters:" -Verbose
+Write-RjRbLog -Message "UserName: $UserName" -Verbose
+Write-RjRbLog -Message "PhoneNumber: $PhoneNumber" -Verbose
+Write-RjRbLog -Message "OnlineVoiceRoutingPolicy: $OnlineVoiceRoutingPolicy" -Verbose
+Write-RjRbLog -Message "TenantDialPlan: $TenantDialPlan" -Verbose
+Write-RjRbLog -Message "TeamsCallingPolicy: $TeamsCallingPolicy" -Verbose
+Write-RjRbLog -Message "TeamsIPPhonePolicy: $TeamsIPPhonePolicy" -Verbose
+
+#endregion
 
 ########################################################
-##             Connect Part
+#region     Connect Part
 ##          
 ########################################################
-# Needs a Microsoft Teams Connection First!
 
-Write-Output "Connection - Connect to Microsoft Teams (PowerShell)"
+Write-Output "Connect to Microsoft Teams..."
 
 try {
-    $CredAutomation = Get-AutomationPSCredential -Name 'teamsautomation'
+    $VerbosePreference = "SilentlyContinue"
+    $tmp = Connect-MicrosoftTeams -Identity -ErrorAction Stop
+    $VerbosePreference = "Continue"
+    # Check if Teams connection is active
+    Get-CsTenant -ErrorAction Stop | Out-Null
 }
 catch {
-    Write-Output "Connection - No automation credentials "teamsautomation" stored. Try newer managed identity approach now"
-}
-
-if ($CredAutomation -notlike "") {
-    $VerbosePreference = "SilentlyContinue"
-    Connect-MicrosoftTeams -Credential $CredAutomation 
-    $VerbosePreference = "Continue"
-}
-else {
-    Write-Output "Connection - Connect as RealmJoin managed identity"
-    $VerbosePreference = "SilentlyContinue"
-    Connect-MicrosoftTeams -Identity -ErrorAction Stop
-    $VerbosePreference = "Continue"
-}
-
-# Check if Teams connection is active
-try {
-    $Test = Get-CsTenant -ErrorAction Stop | Out-Null
-}
-catch {
+    Start-Sleep -Seconds 5
     try {
-        Start-Sleep -Seconds 5
-        $Test = Get-CsTenant -ErrorAction Stop | Out-Null
+        $VerbosePreference = "SilentlyContinue"
+        $tmp = Connect-MicrosoftTeams -Identity -ErrorAction Stop
+        $VerbosePreference = "Continue"
+        # Check if Teams connection is active
+        Get-CsTenant -ErrorAction Stop | Out-Null
     }
     catch {
-        Write-Error -Message "Teams PowerShell session could not be established. Stopping script!" -ErrorAction Continue
-        throw "Teams PowerShell session could not be established. Stopping script!"
+        Write-Error "Microsoft Teams PowerShell session could not be established. Stopping script!" 
         Exit
     }
 }
+
+#endregion
 
 ########################################################
 ##             StatusQuo & Preflight-Check Part


### PR DESCRIPTION
This pull request includes updates to various PowerShell runbooks related to Teams phone management. The changes primarily involve updating the Teams PowerShell module version, adding permissions information, and removing outdated connection methods.

### Updates to Teams PowerShell Module and Permissions:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R9): Documented updates to phone-related runbooks, including module updates and permission additions.
* `user/phone/disable-teams-phone.ps1`, `user/phone/get-teams-user-info.ps1`, `user/phone/grant-teams-user-policies.ps1`, `user/phone/set-teams-permanent-call-forwarding.ps1`, `user/phone/set-teams-phone.ps1`: Updated the Microsoft Teams PowerShell module version to 6.8.0 and added MS Graph and RBAC permissions in the `.NOTES` section. [[1]](diffhunk://#diff-8a4c002fc1010e903ac85894d92cc1a1ea44885d341322e72b20d10e4281cdf6L25-R27) [[2]](diffhunk://#diff-0ad5ca534ae65b41b90cf7a5715309eba08dced4b7eef1abef200eaa4e28e978L26-R28) [[3]](diffhunk://#diff-e9977adcb28590985d899daaf68babcd085f8db5b891206a26eaa586937d1062L47-R49) [[4]](diffhunk://#diff-4ffdf2b17b1d44767d278f4061ff366bce821decfe69f023a610a3d2e86c0579L141-R143) [[5]](diffhunk://#diff-bce88c88ef3c17a6de4cca773b5c070b50b9c1da408e2c7dd7bf415fe5a5caf2L41-R43)

### Logging Enhancements:

* `org/phone/get-teams-phonenumber-assignment.ps1`, `user/phone/disable-teams-phone.ps1`, `user/phone/get-teams-user-info.ps1`, `user/phone/grant-teams-user-policies.ps1`, `user/phone/set-teams-permanent-call-forwarding.ps1`, `user/phone/set-teams-phone.ps1`: Enhanced verbose logging to include caller and version information, and additional parameter details. [[1]](diffhunk://#diff-f7bcca0029e44c335bbcb6aee9fdfe99aa3e43ecbd32d8fb331062e7f48338e3L41-L54) [[2]](diffhunk://#diff-8a4c002fc1010e903ac85894d92cc1a1ea44885d341322e72b20d10e4281cdf6L38-R87) [[3]](diffhunk://#diff-0ad5ca534ae65b41b90cf7a5715309eba08dced4b7eef1abef200eaa4e28e978L43-R56) [[4]](diffhunk://#diff-e9977adcb28590985d899daaf68babcd085f8db5b891206a26eaa586937d1062L65-R122) [[5]](diffhunk://#diff-4ffdf2b17b1d44767d278f4061ff366bce821decfe69f023a610a3d2e86c0579L162-R216) [[6]](diffhunk://#diff-bce88c88ef3c17a6de4cca773b5c070b50b9c1da408e2c7dd7bf415fe5a5caf2L69-R123)

### Connection Method Updates:

* `user/phone/disable-teams-phone.ps1`, `user/phone/grant-teams-user-policies.ps1`, `user/phone/set-teams-permanent-call-forwarding.ps1`, `user/phone/set-teams-phone.ps1`: Removed outdated service user connection methods and ensured the use of managed identity for connecting to Microsoft Teams. [[1]](diffhunk://#diff-8a4c002fc1010e903ac85894d92cc1a1ea44885d341322e72b20d10e4281cdf6L25-R27) [[2]](diffhunk://#diff-e9977adcb28590985d899daaf68babcd085f8db5b891206a26eaa586937d1062L65-R122) [[3]](diffhunk://#diff-4ffdf2b17b1d44767d278f4061ff366bce821decfe69f023a610a3d2e86c0579L162-R216) [[4]](diffhunk://#diff-bce88c88ef3c17a6de4cca773b5c070b50b9c1da408e2c7dd7bf415fe5a5caf2L69-R123)