### PR TITLE
Fix Set Teams call forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # RealmJoin Runbooks Changelog
 
+## 2025-03-05
+- Update User/Phone/Set Teams permanent call forwarding 
+  - Make sure, that unanswered calls settings would be disabled before setting the forwarding
+
 ## 2025-02-24
 - Update all phone related runbooks:
   - Teams PowerShell module updated to 6.8.0

--- a/user/phone/set-teams-permanent-call-forwarding.ps1
+++ b/user/phone/set-teams-permanent-call-forwarding.ps1
@@ -171,7 +171,7 @@ if ($CallerName) {
     Write-RjRbLog -Message "Caller: '$CallerName'" -Verbose
 }
 
-$Version = "1.0.1"
+$Version = "1.0.2"
 Write-RjRbLog -Message "Version: $Version" -Verbose
 Write-RjRbLog -Message "Submitted parameters:" -Verbose
 Write-RjRbLog -Message "UserName: $UserName" -Verbose
@@ -218,8 +218,6 @@ catch {
 ##             StatusQuo & Preflight-Check Part
 ##          
 ########################################################
-
-
 
 # Get StatusQuo
 Write-Output ""


### PR DESCRIPTION
This pull request includes updates to the `user/phone/set-teams-permanent-call-forwarding.ps1` script and the `CHANGELOG.md` file. The changes primarily focus on improving the handling of call forwarding settings for Teams users.

Updates to call forwarding settings:

* [`user/phone/set-teams-permanent-call-forwarding.ps1`](diffhunk://#diff-4ffdf2b17b1d44767d278f4061ff366bce821decfe69f023a610a3d2e86c0579R306-R321): Disabled unanswered call settings before enabling various types of call forwarding to ensure proper configuration.

Version updates:

* [`user/phone/set-teams-permanent-call-forwarding.ps1`](diffhunk://#diff-4ffdf2b17b1d44767d278f4061ff366bce821decfe69f023a610a3d2e86c0579L174-R174): Updated script version from `1.0.1` to `1.0.2`.

Documentation updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R6): Added an entry for the update on 2025-03-05, detailing the changes made to the call forwarding settings.