### PR TITLE
Fix-SetTeamsCallForwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # RealmJoin Runbooks Changelog
 
+## 2025-03-05
+- Update User/Phone/Set Teams permanent call forwarding 
+  - Make sure, that unanswered calls settings would be disabled before setting the forwarding
+
 ## 2025-02-24
 - Update all phone related runbooks:
   - Teams PowerShell module updated to 6.8.0

--- a/user/phone/set-teams-permanent-call-forwarding.ps1
+++ b/user/phone/set-teams-permanent-call-forwarding.ps1
@@ -171,7 +171,7 @@ if ($CallerName) {
     Write-RjRbLog -Message "Caller: '$CallerName'" -Verbose
 }
 
-$Version = "1.0.1"
+$Version = "1.0.2"
 Write-RjRbLog -Message "Version: $Version" -Verbose
 Write-RjRbLog -Message "Submitted parameters:" -Verbose
 Write-RjRbLog -Message "UserName: $UserName" -Verbose
@@ -218,8 +218,6 @@ catch {
 ##             StatusQuo & Preflight-Check Part
 ##          
 ########################################################
-
-
 
 # Get StatusQuo
 Write-Output ""
@@ -305,18 +303,22 @@ if ($TurnOffForward) {
 }
 elseif ($ForwardToVoicemail) {
     Write-Output "Set immediate forwarding to Voicemail"
+    Set-CsUserCallingSettings -Identity $UserName -IsUnansweredEnabled $false
     Set-CsUserCallingSettings -Identity $UserName -IsForwardingEnabled $true -ForwardingType Immediate -ForwardingTargetType Voicemail
 }
 elseif ($ForwardToDelegates) {
     Write-Output "Set immediate forwarding to the delegates which are defined by the user"
+    Set-CsUserCallingSettings -Identity $UserName -IsUnansweredEnabled $false
     Set-CsUserCallingSettings -Identity $UserName -IsForwardingEnabled $true -ForwardingType Immediate -ForwardingTargetType MyDelegates
 }
 elseif ($ForwardTargetTeamsUser -notlike "" ) {
     Write-Output "Set immediate forwarding to Teams user"
+    Set-CsUserCallingSettings -Identity $UserName -IsUnansweredEnabled $false
     Set-CsUserCallingSettings -Identity $UserName -IsForwardingEnabled $true -ForwardingType Immediate -ForwardingTargetType SingleTarget -ForwardingTarget $ForwardTargetTeamsUser
 }
 elseif ($ForwardTargetPhoneNumber -notlike "" ) {
     Write-Output "Set immediate forwarding to phone number"
+    Set-CsUserCallingSettings -Identity $UserName -IsUnansweredEnabled $false
     Set-CsUserCallingSettings -Identity $UserName -IsForwardingEnabled $true -ForwardingType Immediate -ForwardingTargetType SingleTarget -ForwardingTarget $ForwardTargetPhoneNumber
 }
 


### PR DESCRIPTION
This pull request includes updates to the `user/phone/set-teams-permanent-call-forwarding.ps1` script and the `CHANGELOG.md` file. The changes primarily focus on improving the handling of call forwarding settings and updating the version information.

Updates to call forwarding settings:

* [`user/phone/set-teams-permanent-call-forwarding.ps1`](diffhunk://#diff-4ffdf2b17b1d44767d278f4061ff366bce821decfe69f023a610a3d2e86c0579R306-R321): Added commands to disable unanswered call settings before enabling call forwarding to various targets (voicemail, delegates, Teams user, phone number) to ensure proper configuration.

Version and documentation updates:

* [`user/phone/set-teams-permanent-call-forwarding.ps1`](diffhunk://#diff-4ffdf2b17b1d44767d278f4061ff366bce821decfe69f023a610a3d2e86c0579L174-R174): Updated the script version from `1.0.1` to `1.0.2`.
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R6): Added an entry for 2025-03-05 documenting the update to the `Set Teams permanent call forwarding` script with details about the new handling of unanswered call settings.