### PR TITLE
focus group: Device Outphase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,55 +1,81 @@
 # RealmJoin Runbooks Changelog
+
+## 2025-07-21
+
+- Add runbook in Org/Devices:
+  - "Delete stale devices (scheduled)"
+    - Scheduled deletion of stale devices based on last activity date and platform.
+    - Can be scheduled to run automatically and send a report via email.
+  - "List stale devices (scheduled)"
+    - Scheduled report of stale devices based on last activity date and platform.
+    - Automatically sends a report via email.
+  - "Sync device serial numbers to Entra ID (scheduled)"
+    - Syncs serial numbers from Intune devices to Entra ID device extension attributes.
+    - Helps maintain consistency between Intune and Entra ID device records.
+
 ## 2025-06-18
+
 - Add runbook in Org/General:
-  - "Invite external guest users" 
+  - "Invite external guest users"
     - Invite external guest users to the tenant and optionally add them to a specified group.
-  - "Remove primary user" 
+  - "Remove primary user"
     - Remove the primary user from devices in Intune.
 
 ## 2025-06-16
-- Add runbook in Org/Devices: 
-  - "Report Last Device Contact by Range" 
-    - Get the devices based on the last device contact date and time, grouped by the specified ranges. 
-    - Also includes the filtering options for operating system.                                            
-  - "Report Users with more than five devices" 
+
+- Add runbook in Org/Devices:
+  - "Report Last Device Contact by Range"
+    - Get the devices based on the last device contact date and time, grouped by the specified ranges.
+    - Also includes the filtering options for operating system.
+  - "Report Users with more than five devices"
     - Get the users with more than five devices enrolled in Intune.
-  - "Report devices without primary user" 
+  - "Report devices without primary user"
     - Get the devices without a primary user assigned in Intune.
 
 ## 2025-05-02
+
 - Update RealmJoin.RunbookHelper to v0.8.4 in all runbooks
 
 ## 2025-04-22
+
 - Add documentation workflow and scripts to the repository
 
 ## 2025-03-05
-- Update User/Phone/Set Teams permanent call forwarding 
+
+- Update User/Phone/Set Teams permanent call forwarding
   - Make sure, that unanswered calls settings would be disabled before setting the forwarding
 
 ## 2025-02-24
+
 - Update all phone related runbooks:
   - Teams PowerShell module updated to 6.8.0
   - Add Permissions in .Notes section
-  - Remove outdated service user (credential) based connection 
+  - Remove outdated service user (credential) based connection
   - Update version number
 
 ## 2025-02-19
+
 - New Runbook: Org/Phone/Get Teams Phone Number Assignment - Get the phone number assignment of the specified phone number and output the user if assigned
 
 ## 2025-02-13
+
 - Update Runbook org/devices/ "outphase-devices" - add support for serialnumbers
 
 ## 2025-02-12
+
 - Fix: add-devices-of-users-to-group_scheduled - add AndroidForWork condition
 
 ## 2025-02-11
+
 - New Runbook: Group/General/List all members - list members of a specified EntraID group, including members from nested groups
 
 ## 2025-01-24
+
 - Check UpdateAbleAssets (device and group): Adapted to new graph response, general rework
 - Minor fixes (like typos) to multiple runbooks
 
 ## 2025-01-15
+
 - Update Runbook: get-teams-user-info
   - Version 1.0.1
   - Changes:
@@ -62,17 +88,20 @@
     - Remove old credential based connect from the Teams PowerShell Module
 
 ## 2024-12-05
+
 - Add version info to all runbooks
 
 ## 2024-11-19
+
 - Fix: Add devices of users to group: Filters for iOS/iPadOS updated
 
 ## 2024-11-27
+
 - New Runbook: Multi-Device Outphasing
 
 ## 2024-11-14
 
-- New Runbook: Add/remove a nested group to/from a group. 
+- New Runbook: Add/remove a nested group to/from a group.
 
 ## 2024-11-11
 

--- a/org/devices/delete-stale-devices_scheduled.ps1
+++ b/org/devices/delete-stale-devices_scheduled.ps1
@@ -1,0 +1,359 @@
+<#
+  .SYNOPSIS
+  Scheduled deletion of stale devices based on last activity date and platform.
+
+  .DESCRIPTION
+  Identifies, lists, and deletes devices that haven't been active for a specified number of days.
+  Can be scheduled to run automatically and send a report via email.
+
+  .NOTES
+  Permissions (Graph):
+  - DeviceManagementManagedDevices.Read.All
+  - DeviceManagementManagedDevices.DeleteAll
+  - Directory.Read.All
+  - Device.Read.All
+  - Mail.Send
+
+  .PARAMETER Days
+  Number of days without activity to be considered stale.
+
+  .PARAMETER Windows
+  Include Windows devices in the results.
+
+  .PARAMETER MacOS
+  Include macOS devices in the results.
+
+  .PARAMETER iOS
+  Include iOS devices in the results.
+
+  .PARAMETER Android
+  Include Android devices in the results.
+
+  .PARAMETER DeleteDevices
+  If set to true, the script will delete the stale devices. If false, it will only report them.
+
+  .PARAMETER ConfirmDeletion
+  If set to true, the script will prompt for confirmation before deleting devices.
+  Should be set to false for scheduled runs.
+
+  .PARAMETER sendAlertTo
+  Email address to send the report to.
+
+  .PARAMETER sendAlertFrom
+  Email address to send the report from.
+
+  .PARAMETER CallerName
+  Caller name for auditing purposes.
+#>
+
+#Requires -Modules @{ModuleName = "RealmJoin.RunbookHelper"; ModuleVersion = "0.8.3" }
+
+param(
+    [int] $Days = 30,
+    [bool] $Windows = $true,
+    [bool] $MacOS = $true,
+    [bool] $iOS = $true,
+    [bool] $Android = $true,
+    [bool] $DeleteDevices = $false,
+    [bool] $ConfirmDeletion = $true,
+    [string] $sendAlertTo = "support@glueckkanja.com",
+    [string] $sendAlertFrom = "runbook@glueckkanja.com",
+    # CallerName is tracked purely for auditing purposes
+    [Parameter(Mandatory = $true)]
+    [string] $CallerName
+)
+
+Write-RjRbLog -Message "Caller: '$CallerName'" -Verbose
+
+# Connect to Microsoft Graph
+Connect-RjRbGraph
+
+# Get tenant information
+Write-Output "## Retrieving tenant information..."
+$organization = Invoke-RjRbRestMethodGraph -Resource "/organization" -ErrorAction SilentlyContinue
+$tenantDisplayName = "Unknown Tenant"
+
+if ($organization -and $organization.Count -gt 0) {
+    $tenantDisplayName = $organization[0].displayName
+    Write-Output "## Tenant: $tenantDisplayName"
+}
+Write-Output ""
+
+# Calculate the date threshold for stale devices
+$beforeDate = (Get-Date).AddDays(-$Days) | Get-Date -Format "yyyy-MM-dd"
+
+# Prepare filter for the Graph API query
+$filter = "lastSyncDateTime le ${beforeDate}T00:00:00Z"
+
+# Define the properties to select
+$selectString = "deviceName, lastSyncDateTime, enrolledDateTime, userPrincipalName, id, serialNumber, manufacturer, model, operatingSystem, osVersion, complianceState"
+
+# Get all stale devices
+Write-Output "## Listing devices not active for at least $Days days"
+Write-Output ""
+
+$devices = Invoke-RjRbRestMethodGraph -Resource "/deviceManagement/managedDevices" -OdSelect $selectString -OdFilter $filter -FollowPaging
+
+# Filter devices by platform based on user selection
+$filteredDevices = @()
+
+foreach ($device in $devices) {
+    $include = $false
+    
+    # Check if the device's platform matches any of the selected platforms
+    if ($Windows -and $device.operatingSystem -eq "Windows") {
+        $include = $true
+    }
+    elseif ($MacOS -and $device.operatingSystem -eq "macOS") {
+        $include = $true
+    }
+    elseif ($iOS -and $device.operatingSystem -eq "iOS") {
+        $include = $true
+    }
+    elseif ($Android -and $device.operatingSystem -eq "Android") {
+        $include = $true
+    }
+    
+    if ($include) {
+        # Try to get additional user information
+        try {
+            $userInfo = Invoke-RjRbRestMethodGraph -Resource "/Users/$($device.userPrincipalName)" -OdSelect "displayName, city, usageLocation" -ErrorAction SilentlyContinue
+            
+            if ($userInfo) {
+                $device | Add-Member -Name "userDisplayName" -Value $userInfo.displayName -MemberType "NoteProperty" -Force
+                $device | Add-Member -Name "userLocation" -Value "$($userInfo.city), $($userInfo.usageLocation)" -MemberType "NoteProperty" -Force
+            }
+        }
+        catch {
+            Write-RjRbLog -Message "Could not retrieve user info for $($device.userPrincipalName): $_" -Verbose
+        }
+        
+        $filteredDevices += $device
+    }
+}
+
+# Display summary counts
+Write-Output "## Summary of stale devices for ${tenantDisplayName}:"
+Write-Output "Total devices: $($filteredDevices.Count)"
+
+if ($Windows) {
+    $windowsCount = ($filteredDevices | Where-Object { $_.operatingSystem -eq "Windows" }).Count
+    Write-Output "Windows devices: $windowsCount"
+}
+
+if ($MacOS) {
+    $macOSCount = ($filteredDevices | Where-Object { $_.operatingSystem -eq "macOS" }).Count
+    Write-Output "macOS devices: $macOSCount"
+}
+
+if ($iOS) {
+    $iOSCount = ($filteredDevices | Where-Object { $_.operatingSystem -eq "iOS" }).Count
+    Write-Output "iOS devices: $iOSCount"
+}
+
+if ($Android) {
+    $androidCount = ($filteredDevices | Where-Object { $_.operatingSystem -eq "Android" }).Count
+    Write-Output "Android devices: $androidCount"
+}
+
+Write-Output ""
+Write-Output "## Detailed list of stale devices:"
+Write-Output ""
+
+# Display the filtered devices
+$filteredDevices | Sort-Object -Property lastSyncDateTime | Format-Table -AutoSize -Property @{
+    name       = "LastSync";
+    expression = { Get-Date $_.lastSyncDateTime -Format yyyy-MM-dd }
+}, @{
+    name       = "DeviceName";
+    expression = { if ($_.deviceName.Length -gt 15) { $_.deviceName.substring(0, 14) + ".." } else { $_.deviceName } }
+}, @{
+    name       = "DeviceID";
+    expression = { if ($_.id.Length -gt 15) { $_.id.substring(0, 14) + ".." } else { $_.id } }
+}, @{
+    name       = "SerialNumber";
+    expression = { if ($_.serialNumber.Length -gt 15) { $_.serialNumber.substring(0, 14) + ".." } else { $_.serialNumber } }
+}, @{
+    name       = "PrimaryUser";
+    expression = { if ($_.userPrincipalName.Length -gt 20) { $_.userPrincipalName.substring(0, 19) + ".." } else { $_.userPrincipalName } }
+}, @{
+    name       = "OS";
+    expression = { $_.operatingSystem }
+}
+
+# Create HTML content for email
+Write-Output ""
+
+# Create HTML header
+$HTMLBody = "<h2>Stale Devices Report - $tenantDisplayName</h2>"
+$HTMLBody += "<p>This report shows devices that have not been active for at least $Days days.</p>"
+
+# Add summary section
+$HTMLBody += "<h3>Summary</h3>"
+$HTMLBody += "<ul>"
+$HTMLBody += "<li>Total devices: $($filteredDevices.Count)</li>"
+
+if ($Windows) {
+    $windowsCount = ($filteredDevices | Where-Object { $_.operatingSystem -eq "Windows" }).Count
+    $HTMLBody += "<li>Windows devices: $windowsCount</li>"
+}
+
+if ($MacOS) {
+    $macOSCount = ($filteredDevices | Where-Object { $_.operatingSystem -eq "macOS" }).Count
+    $HTMLBody += "<li>macOS devices: $macOSCount</li>"
+}
+
+if ($iOS) {
+    $iOSCount = ($filteredDevices | Where-Object { $_.operatingSystem -eq "iOS" }).Count
+    $HTMLBody += "<li>iOS devices: $iOSCount</li>"
+}
+
+if ($Android) {
+    $androidCount = ($filteredDevices | Where-Object { $_.operatingSystem -eq "Android" }).Count
+    $HTMLBody += "<li>Android devices: $androidCount</li>"
+}
+
+$HTMLBody += "</ul>"
+
+# Create HTML table
+$HTMLBody += "<h3>Detailed List</h3>"
+
+if ($filteredDevices.Count -gt 0) {
+    $HTMLBody += "<table border='1' style='border-collapse: collapse; width: 100%;'>"
+    $HTMLBody += "<tr style='background-color: #f2f2f2;'>"
+    $HTMLBody += "<th style='padding: 8px; text-align: left;'>Last Sync</th>"
+    $HTMLBody += "<th style='padding: 8px; text-align: left;'>Device Name</th>"
+    $HTMLBody += "<th style='padding: 8px; text-align: left;'>Device ID</th>"
+    $HTMLBody += "<th style='padding: 8px; text-align: left;'>Serial Number</th>"
+    $HTMLBody += "<th style='padding: 8px; text-align: left;'>Primary User</th>"
+    $HTMLBody += "<th style='padding: 8px; text-align: left;'>OS</th>"
+    $HTMLBody += "</tr>"
+    
+    $sortedDevices = $filteredDevices | Sort-Object -Property lastSyncDateTime
+    
+    foreach ($device in $sortedDevices) {
+        $lastSync = Get-Date $device.lastSyncDateTime -Format yyyy-MM-dd
+        $deviceName = $device.deviceName
+        $deviceId = $device.id
+        $serialNumber = $device.serialNumber
+        $user = $device.userPrincipalName
+        $os = $device.operatingSystem
+        
+        $HTMLBody += "<tr>"
+        $HTMLBody += "<td style='padding: 8px;'>$lastSync</td>"
+        $HTMLBody += "<td style='padding: 8px;'>$deviceName</td>"
+        $HTMLBody += "<td style='padding: 8px;'>$deviceId</td>"
+        $HTMLBody += "<td style='padding: 8px;'>$serialNumber</td>"
+        $HTMLBody += "<td style='padding: 8px;'>$user</td>"
+        $HTMLBody += "<td style='padding: 8px;'>$os</td>"
+        $HTMLBody += "</tr>"
+    }
+    
+    $HTMLBody += "</table>"
+}
+else {
+    $HTMLBody += "<p>No stale devices found matching the selected criteria.</p>"
+}
+
+# Add deletion information if applicable
+if ($DeleteDevices) {
+    $HTMLBody += "<h3>Deletion Information</h3>"
+    $HTMLBody += "<p>The stale devices listed above have been deleted from Intune.</p>"
+}
+
+# Process device deletion if requested
+$deletedDevices = @()
+$failedDeletions = @()
+
+if ($DeleteDevices -and $filteredDevices.Count -gt 0) {
+    Write-Output "## Device Deletion"
+    
+    # Confirm deletion if required
+    $proceedWithDeletion = $true
+    if ($ConfirmDeletion) {
+        $confirmation = Read-Host "Are you sure you want to delete $($filteredDevices.Count) stale devices? (Y/N)"
+        if ($confirmation -ne "Y") {
+            $proceedWithDeletion = $false
+            Write-Output "Deletion cancelled by user."
+        }
+    }
+    
+    if ($proceedWithDeletion) {
+        Write-Output "Deleting $($filteredDevices.Count) stale devices..."
+        
+        foreach ($device in $filteredDevices) {
+            try {
+                Write-Output "Deleting device: $($device.deviceName) (ID: $($device.id))"
+                Invoke-RjRbRestMethodGraph -Resource "/deviceManagement/managedDevices/$($device.id)" -Method DELETE -ErrorAction Stop
+                $deletedDevices += $device
+                Write-Output "Successfully deleted device: $($device.deviceName)"
+            }
+            catch {
+                Write-Output "Failed to delete device $($device.deviceName): $_"
+                Write-RjRbLog -Message "Failed to delete device $($device.deviceName): $_" -Verbose
+                $failedDeletions += $device
+            }
+        }
+        
+        # Add deletion results to HTML
+        $HTMLBody += "<h3>Deletion Results</h3>"
+        $HTMLBody += "<p>Successfully deleted: $($deletedDevices.Count) devices</p>"
+        
+        if ($failedDeletions.Count -gt 0) {
+            $HTMLBody += "<p>Failed to delete: $($failedDeletions.Count) devices</p>"
+            $HTMLBody += "<h4>Failed Deletions</h4>"
+            $HTMLBody += "<ul>"
+            foreach ($failedDevice in $failedDeletions) {
+                $HTMLBody += "<li>$($failedDevice.deviceName) (ID: $($failedDevice.id))</li>"
+            }
+            $HTMLBody += "</ul>"
+        }
+    }
+    else {
+        $HTMLBody += "<p>Device deletion was cancelled.</p>"
+    }
+}
+
+# Send email
+Write-Output "## Preparing email report to send to $sendAlertTo"
+$emailSubject = "[Automated Report] Stale Devices"
+if ($DeleteDevices) {
+    $emailSubject += " - DELETION"
+}
+$emailSubject += " - $tenantDisplayName - $Days days"
+
+$message = @{
+    subject      = $emailSubject
+    body         = @{
+        contentType = "HTML"
+        content     = $HTMLBody
+    }
+    toRecipients = @(
+        @{
+            emailAddress = @{
+                address = $sendAlertTo
+            }
+        }
+    )
+}
+
+Write-Output "Sending report to '$sendAlertTo'..."
+try {
+    Invoke-RjRbRestMethodGraph -Resource "/users/$sendAlertFrom/sendMail" -Method POST -Body @{ message = $message } -ContentType "application/json" | Out-Null
+    Write-Output "Report successfully sent to '$sendAlertTo'."
+}
+catch {
+    Write-Output "Error sending email: $_"
+    Write-RjRbLog -Message "Error sending email: $_" -Verbose
+}
+
+# Output summary
+Write-Output ""
+Write-Output "## Operation Summary:"
+Write-Output "Stale devices found: $($filteredDevices.Count)"
+if ($DeleteDevices) {
+    Write-Output "Devices successfully deleted: $($deletedDevices.Count)"
+    if ($failedDeletions.Count -gt 0) {
+        Write-Output "Devices failed to delete: $($failedDeletions.Count)"
+    }
+}

--- a/org/devices/list-stale-devices_scheduled.ps1
+++ b/org/devices/list-stale-devices_scheduled.ps1
@@ -1,0 +1,267 @@
+<#
+  .SYNOPSIS
+  Scheduled report of stale devices based on last activity date and platform.
+
+  .DESCRIPTION
+  Identifies and lists devices that haven't been active for a specified number of days.
+  Automatically sends a report via email.
+
+  .NOTES
+  Permissions (Graph):
+  - DeviceManagementManagedDevices.Read.All
+  - Directory.Read.All
+  - Device.Read.All
+  - Mail.Send
+
+  .PARAMETER Days
+  Number of days without activity to be considered stale.
+
+  .PARAMETER Windows
+  Include Windows devices in the results.
+
+  .PARAMETER MacOS
+  Include macOS devices in the results.
+
+  .PARAMETER iOS
+  Include iOS devices in the results.
+
+  .PARAMETER Android
+  Include Android devices in the results.
+
+  .PARAMETER sendAlertTo
+  Email address to send the report to.
+
+  .PARAMETER sendAlertFrom
+  Email address to send the report from.
+
+  .PARAMETER CallerName
+  Caller name for auditing purposes.
+#>
+
+#Requires -Modules @{ModuleName = "RealmJoin.RunbookHelper"; ModuleVersion = "0.8.3" }
+
+param(
+    [int] $Days = 30,
+    [bool] $Windows = $true,
+    [bool] $MacOS = $true,
+    [bool] $iOS = $true,
+    [bool] $Android = $true,
+    [string] $sendAlertTo = "support@glueckkanja.com",
+    [string] $sendAlertFrom = "runbook@glueckkanja.com",
+    # CallerName is tracked purely for auditing purposes
+    [Parameter(Mandatory = $true)]
+    [string] $CallerName
+)
+
+Write-RjRbLog -Message "Caller: '$CallerName'" -Verbose
+
+# Connect to Microsoft Graph
+Connect-RjRbGraph
+
+# Get tenant information
+Write-Output "## Retrieving tenant information..."
+$organization = Invoke-RjRbRestMethodGraph -Resource "/organization" -ErrorAction SilentlyContinue
+$tenantDisplayName = "Unknown Tenant"
+
+if ($organization -and $organization.Count -gt 0) {
+    $tenantDisplayName = $organization[0].displayName
+    Write-Output "## Tenant: $tenantDisplayName"
+}
+Write-Output ""
+
+# Calculate the date threshold for stale devices
+$beforeDate = (Get-Date).AddDays(-$Days) | Get-Date -Format "yyyy-MM-dd"
+
+# Prepare filter for the Graph API query
+$filter = "lastSyncDateTime le ${beforeDate}T00:00:00Z"
+
+# Define the properties to select
+$selectString = "deviceName, lastSyncDateTime, enrolledDateTime, userPrincipalName, id, serialNumber, manufacturer, model, operatingSystem, osVersion, complianceState"
+
+# Get all stale devices
+Write-Output "## Listing devices not active for at least $Days days"
+Write-Output ""
+
+$devices = Invoke-RjRbRestMethodGraph -Resource "/deviceManagement/managedDevices" -OdSelect $selectString -OdFilter $filter -FollowPaging
+
+# Filter devices by platform based on user selection
+$filteredDevices = @()
+
+foreach ($device in $devices) {
+    $include = $false
+    
+    # Check if the device's platform matches any of the selected platforms
+    if ($Windows -and $device.operatingSystem -eq "Windows") {
+        $include = $true
+    }
+    elseif ($MacOS -and $device.operatingSystem -eq "macOS") {
+        $include = $true
+    }
+    elseif ($iOS -and $device.operatingSystem -eq "iOS") {
+        $include = $true
+    }
+    elseif ($Android -and $device.operatingSystem -eq "Android") {
+        $include = $true
+    }
+    
+    if ($include) {
+        # Try to get additional user information
+        try {
+            $userInfo = Invoke-RjRbRestMethodGraph -Resource "/Users/$($device.userPrincipalName)" -OdSelect "displayName, city, usageLocation" -ErrorAction SilentlyContinue
+            
+            if ($userInfo) {
+                $device | Add-Member -Name "userDisplayName" -Value $userInfo.displayName -MemberType "NoteProperty" -Force
+                $device | Add-Member -Name "userLocation" -Value "$($userInfo.city), $($userInfo.usageLocation)" -MemberType "NoteProperty" -Force
+            }
+        }
+        catch {
+            Write-RjRbLog -Message "Could not retrieve user info for $($device.userPrincipalName): $_" -Verbose
+        }
+        
+        $filteredDevices += $device
+    }
+}
+
+# Display summary counts
+Write-Output "## Summary of stale devices for ${tenantDisplayName}:"
+Write-Output "Total devices: $($filteredDevices.Count)"
+
+if ($Windows) {
+    $windowsCount = ($filteredDevices | Where-Object { $_.operatingSystem -eq "Windows" }).Count
+    Write-Output "Windows devices: $windowsCount"
+}
+
+if ($MacOS) {
+    $macOSCount = ($filteredDevices | Where-Object { $_.operatingSystem -eq "macOS" }).Count
+    Write-Output "macOS devices: $macOSCount"
+}
+
+if ($iOS) {
+    $iOSCount = ($filteredDevices | Where-Object { $_.operatingSystem -eq "iOS" }).Count
+    Write-Output "iOS devices: $iOSCount"
+}
+
+if ($Android) {
+    $androidCount = ($filteredDevices | Where-Object { $_.operatingSystem -eq "Android" }).Count
+    Write-Output "Android devices: $androidCount"
+}
+
+Write-Output ""
+Write-Output "## Detailed list of stale devices:"
+Write-Output ""
+
+# Display the filtered devices
+$filteredDevices | Sort-Object -Property lastSyncDateTime | Format-Table -AutoSize -Property @{
+    name       = "LastSync";
+    expression = { Get-Date $_.lastSyncDateTime -Format yyyy-MM-dd }
+}, @{
+    name       = "DeviceName";
+    expression = { if ($_.deviceName.Length -gt 15) { $_.deviceName.substring(0, 14) + ".." } else { $_.deviceName } }
+}, @{
+    name       = "DeviceID";
+    expression = { if ($_.id.Length -gt 15) { $_.id.substring(0, 14) + ".." } else { $_.id } }
+}, @{
+    name       = "SerialNumber";
+    expression = { if ($_.serialNumber.Length -gt 15) { $_.serialNumber.substring(0, 14) + ".." } else { $_.serialNumber } }
+}, @{
+    name       = "PrimaryUser";
+    expression = { if ($_.userPrincipalName.Length -gt 20) { $_.userPrincipalName.substring(0, 19) + ".." } else { $_.userPrincipalName } }
+}
+
+# Create HTML content for email
+Write-Output ""
+Write-Output "## Preparing email report to send to $sendAlertTo"
+
+# Create HTML header
+$HTMLBody = "<h2>Stale Devices Report - $tenantDisplayName</h2>"
+$HTMLBody += "<p>This report shows devices that have not been active for at least $Days days.</p>"
+
+# Add summary section
+$HTMLBody += "<h3>Summary</h3>"
+$HTMLBody += "<ul>"
+$HTMLBody += "<li>Total devices: $($filteredDevices.Count)</li>"
+
+if ($Windows) {
+    $windowsCount = ($filteredDevices | Where-Object { $_.operatingSystem -eq "Windows" }).Count
+    $HTMLBody += "<li>Windows devices: $windowsCount</li>"
+}
+
+if ($MacOS) {
+    $macOSCount = ($filteredDevices | Where-Object { $_.operatingSystem -eq "macOS" }).Count
+    $HTMLBody += "<li>macOS devices: $macOSCount</li>"
+}
+
+if ($iOS) {
+    $iOSCount = ($filteredDevices | Where-Object { $_.operatingSystem -eq "iOS" }).Count
+    $HTMLBody += "<li>iOS devices: $iOSCount</li>"
+}
+
+if ($Android) {
+    $androidCount = ($filteredDevices | Where-Object { $_.operatingSystem -eq "Android" }).Count
+    $HTMLBody += "<li>Android devices: $androidCount</li>"
+}
+
+$HTMLBody += "</ul>"
+
+# Create HTML table
+$HTMLBody += "<h3>Detailed List</h3>"
+
+if ($filteredDevices.Count -gt 0) {
+    $HTMLBody += "<table border='1' style='border-collapse: collapse; width: 100%;'>"
+    $HTMLBody += "<tr style='background-color: #f2f2f2;'>"
+    $HTMLBody += "<th style='padding: 8px; text-align: left;'>Last Sync</th>"
+    $HTMLBody += "<th style='padding: 8px; text-align: left;'>Device Name</th>"
+    $HTMLBody += "<th style='padding: 8px; text-align: left;'>Device ID</th>"
+    $HTMLBody += "<th style='padding: 8px; text-align: left;'>Serial Number</th>"
+    $HTMLBody += "<th style='padding: 8px; text-align: left;'>Primary User</th>"
+    $HTMLBody += "</tr>"
+    
+    $sortedDevices = $filteredDevices | Sort-Object -Property lastSyncDateTime
+    
+    foreach ($device in $sortedDevices) {
+        $lastSync = Get-Date $device.lastSyncDateTime -Format yyyy-MM-dd
+        $deviceName = $device.deviceName
+        $deviceId = $device.id
+        $serialNumber = $device.serialNumber
+        $user = $device.userPrincipalName
+        
+        $HTMLBody += "<tr>"
+        $HTMLBody += "<td style='padding: 8px;'>$lastSync</td>"
+        $HTMLBody += "<td style='padding: 8px;'>$deviceName</td>"
+        $HTMLBody += "<td style='padding: 8px;'>$deviceId</td>"
+        $HTMLBody += "<td style='padding: 8px;'>$serialNumber</td>"
+        $HTMLBody += "<td style='padding: 8px;'>$user</td>"
+        $HTMLBody += "</tr>"
+    }
+    
+    $HTMLBody += "</table>"
+}
+else {
+    $HTMLBody += "<p>No stale devices found matching the selected criteria.</p>"
+}
+
+# Send email
+$message = @{
+    subject      = "[Automated Report] Stale Devices Report - $tenantDisplayName - $Days days"
+    body         = @{
+        contentType = "HTML"
+        content     = $HTMLBody
+    }
+    toRecipients = @(
+        @{
+            emailAddress = @{
+                address = $sendAlertTo
+            }
+        }
+    )
+}
+
+Write-Output "Sending report to '$sendAlertTo'..."
+try {
+    Invoke-RjRbRestMethodGraph -Resource "/users/$sendAlertFrom/sendMail" -Method POST -Body @{ message = $message } -ContentType "application/json" | Out-Null
+    Write-Output "Report successfully sent to '$sendAlertTo'."
+}
+catch {
+    Write-Output "Error sending email: $_"
+    Write-RjRbLog -Message "Error sending email: $_" -Verbose
+}

--- a/org/devices/sync-device-serialnumbers-to-entraid_scheduled.ps1
+++ b/org/devices/sync-device-serialnumbers-to-entraid_scheduled.ps1
@@ -1,0 +1,329 @@
+<#
+  .SYNOPSIS
+  Syncs serial numbers from Intune devices to Azure AD device extension attributes.
+
+  .DESCRIPTION
+  This runbook retrieves all managed devices from Intune, extracts their serial numbers,
+  and updates the corresponding Azure AD device objects' extension attributes.
+  This helps maintain consistency between Intune and Azure AD device records.
+
+  .NOTES
+  Permissions (Graph):
+  - DeviceManagementManagedDevices.Read.All
+  - Directory.ReadWrite.All
+  - Device.ReadWrite.All
+
+  .PARAMETER ExtensionAttributeName
+  The name of the extension attribute to update with the serial number.
+
+  .PARAMETER ProcessAllDevices
+  If true, processes all devices. If false, only processes devices with missing or mismatched serial numbers in AAD.
+
+  .PARAMETER MaxDevicesToProcess
+  Maximum number of devices to process in a single run. Use 0 for unlimited.
+
+  .PARAMETER sendReportTo
+  Email address to send the report to. If empty, no email will be sent.
+
+  .PARAMETER sendReportFrom
+  Email address to send the report from.
+
+  .PARAMETER CallerName
+  Caller name for auditing purposes.
+#>
+
+#Requires -Modules @{ModuleName = "RealmJoin.RunbookHelper"; ModuleVersion = "0.8.3" }
+
+param(
+    [int] $ExtensionAttributeNumber = 1,
+    [bool] $ProcessAllDevices = $false,
+    [int] $MaxDevicesToProcess = 0,
+    [string] $sendReportTo = "",
+    [string] $sendReportFrom = "runbook@glueckkanja.com",
+    # CallerName is tracked purely for auditing purposes
+    [Parameter(Mandatory = $true)]
+    [string] $CallerName
+)
+
+# Validate extension attribute number
+if ($ExtensionAttributeNumber -lt 1 -or $ExtensionAttributeNumber -gt 15) {
+    Write-Output "Error: ExtensionAttributeNumber must be between 1 and 15."
+    exit 1
+}
+
+# Define the extension attribute name based on the number
+$ExtensionAttributeName = "extensionAttribute$ExtensionAttributeNumber"
+
+Write-RjRbLog -Message "Caller: '$CallerName'" -Verbose
+
+# Connect to Microsoft Graph
+Connect-RjRbGraph
+
+# Get tenant information
+Write-Output "## Retrieving tenant information..."
+$organization = Invoke-RjRbRestMethodGraph -Resource "/organization" -ErrorAction SilentlyContinue
+$tenantDisplayName = "Unknown Tenant"
+
+if ($organization -and $organization.Count -gt 0) {
+    $tenantDisplayName = $organization[0].displayName
+    Write-Output "## Tenant: $tenantDisplayName"
+}
+Write-Output ""
+
+# Define the properties to select from Intune devices
+$intuneSelectString = "deviceName, id, serialNumber, azureADDeviceId"
+
+# Get all managed devices from Intune
+Write-Output "## Retrieving managed devices from Intune..."
+$intuneDevices = Invoke-RjRbRestMethodGraph -Resource "/deviceManagement/managedDevices" -OdSelect $intuneSelectString -FollowPaging
+
+Write-Output "Found $($intuneDevices.Count) devices in Intune."
+Write-Output ""
+
+# Get all devices from Azure AD
+Write-Output "## Retrieving devices from Azure AD..."
+$aadDevices = Invoke-RjRbRestMethodGraph -Resource "/devices" -OdSelect "id,displayName,extensionAttributes" -FollowPaging
+
+Write-Output "Found $($aadDevices.Count) devices in Azure AD."
+Write-Output ""
+
+# Initialize counters and arrays for reporting
+$processedCount = 0
+$updatedCount = 0
+$skippedCount = 0
+$errorCount = 0
+$updatedDevices = @()
+$skippedDevices = @()
+$errorDevices = @()
+
+# Process each Intune device
+Write-Output "## Processing devices..."
+foreach ($intuneDevice in $intuneDevices) {
+    # Check if we've reached the maximum number of devices to process
+    if ($MaxDevicesToProcess -gt 0 -and $processedCount -ge $MaxDevicesToProcess) {
+        Write-Output "Reached maximum number of devices to process ($MaxDevicesToProcess). Stopping."
+        break
+    }
+
+    $processedCount++
+    
+    # Skip devices without a serial number
+    if ([string]::IsNullOrEmpty($intuneDevice.serialNumber)) {
+        Write-Output "[$($processedCount)/$($intuneDevices.Count)] Device $($intuneDevice.deviceName) (ID: $($intuneDevice.id)) has no serial number. Skipping."
+        $skippedDevices += [PSCustomObject]@{
+            DeviceName   = $intuneDevice.deviceName
+            IntuneID     = $intuneDevice.id
+            AzureADID    = ""
+            SerialNumber = "N/A"
+            Reason       = "No serial number in Intune"
+        }
+        $skippedCount++
+        continue
+    }
+
+    # Find the corresponding Azure AD device by display name
+    $matchingAadDevice = $aadDevices | Where-Object { $_.displayName -eq $intuneDevice.deviceName } | Select-Object -First 1
+
+    if (-not $matchingAadDevice) {
+        Write-Output "[$($processedCount)/$($intuneDevices.Count)] No matching Azure AD device found for $($intuneDevice.deviceName) (ID: $($intuneDevice.id)). Skipping."
+        $skippedDevices += [PSCustomObject]@{
+            DeviceName   = $intuneDevice.deviceName
+            IntuneID     = $intuneDevice.id
+            AzureADID    = "N/A"
+            SerialNumber = $intuneDevice.serialNumber
+            Reason       = "No matching Azure AD device found"
+        }
+        $skippedCount++
+        continue
+    }
+
+    # Get the corresponding Azure AD device
+    try {
+        $aadDevice = $matchingAadDevice
+        
+        # Check if the extension attribute already exists and has the correct value
+        $currentExtensionValue = $null
+        if ($aadDevice.extensionAttributes -and $aadDevice.extensionAttributes.$ExtensionAttributeName) {
+            $currentExtensionValue = $aadDevice.extensionAttributes.$ExtensionAttributeName
+        }
+
+        # If we're only processing devices with missing or mismatched serial numbers and this one matches, skip it
+        if (-not $ProcessAllDevices -and $currentExtensionValue -eq $intuneDevice.serialNumber) {
+            Write-Output "[$($processedCount)/$($intuneDevices.Count)] Device $($intuneDevice.deviceName) (ID: $($intuneDevice.id)) already has correct serial number in AAD. Skipping."
+            $skippedDevices += [PSCustomObject]@{
+                DeviceName   = $intuneDevice.deviceName
+                IntuneID     = $intuneDevice.id
+                AzureADID    = $aadDevice.id
+                SerialNumber = $intuneDevice.serialNumber
+                Reason       = "Serial number already matches"
+            }
+            $skippedCount++
+            continue
+        }
+
+        # Prepare the update body
+        $updateBody = @{
+            extensionAttributes = @{
+                $ExtensionAttributeName = $intuneDevice.serialNumber
+            }
+        }
+
+        # Try to update the Azure AD device
+        try {
+            Invoke-RjRbRestMethodGraph -Resource "/devices/$($aadDevice.id)" -Method PATCH -Body $updateBody -ContentType "application/json" | Out-Null
+        }
+        catch {
+            # If we get an authentication error, try to reconnect and retry
+            if ($_.Exception.Message -like "*InvalidAuthenticationToken*") {
+                Write-Output "Authentication token expired. Reconnecting to Microsoft Graph..."
+                Connect-RjRbGraph
+                Invoke-RjRbRestMethodGraph -Resource "/devices/$($aadDevice.id)" -Method PATCH -Body $updateBody -ContentType "application/json" | Out-Null
+            }
+            else {
+                throw
+            }
+        }
+        
+        Write-Output "[$($processedCount)/$($intuneDevices.Count)] Updated device $($intuneDevice.deviceName) (ID: $($intuneDevice.id)) with serial number $($intuneDevice.serialNumber)"
+        $updatedDevices += [PSCustomObject]@{
+            DeviceName    = $intuneDevice.deviceName
+            IntuneID      = $intuneDevice.id
+            AzureADID     = $aadDevice.id
+            SerialNumber  = $intuneDevice.serialNumber
+            PreviousValue = $currentExtensionValue
+        }
+        $updatedCount++
+    }
+    catch {
+        Write-Output "[$($processedCount)/$($intuneDevices.Count)] Error processing device $($intuneDevice.deviceName) (ID: $($intuneDevice.id)): $_"
+        Write-RjRbLog -Message "Error processing device $($intuneDevice.deviceName) (ID: $($intuneDevice.id)): $_" -Verbose
+        $errorDevices += [PSCustomObject]@{
+            DeviceName   = $intuneDevice.deviceName
+            IntuneID     = $intuneDevice.id
+            AzureADID    = $matchingAadDevice ? $matchingAadDevice.id : "N/A"
+            SerialNumber = $intuneDevice.serialNumber
+            Error        = $_.Exception.Message
+        }
+        $errorCount++
+    }
+}
+
+# Display summary
+Write-Output ""
+Write-Output "## Summary:"
+Write-Output "Total devices in Intune: $($intuneDevices.Count)"
+Write-Output "Devices processed: $processedCount"
+Write-Output "Devices updated: $updatedCount"
+Write-Output "Devices skipped: $skippedCount"
+Write-Output "Devices with errors: $errorCount"
+Write-Output ""
+
+# Send email report if requested
+if (-not [string]::IsNullOrEmpty($sendReportTo)) {
+    Write-Output "## Preparing email report to send to $sendReportTo"
+    
+    # Create HTML content for email
+    $HTMLBody = "<h2>Device Serial Number Sync Report - $tenantDisplayName</h2>"
+    $HTMLBody += "<p>This report shows the results of syncing serial numbers from Intune devices to Azure AD device extension attributes.</p>"
+    
+    # Add summary section
+    $HTMLBody += "<h3>Summary</h3>"
+    $HTMLBody += "<ul>"
+    $HTMLBody += "<li>Total devices in Intune: $($intuneDevices.Count)</li>"
+    $HTMLBody += "<li>Devices processed: $processedCount</li>"
+    $HTMLBody += "<li>Devices updated: $updatedCount</li>"
+    $HTMLBody += "<li>Devices skipped: $skippedCount</li>"
+    $HTMLBody += "<li>Devices with errors: $errorCount</li>"
+    $HTMLBody += "</ul>"
+    
+    # Add updated devices section
+    if ($updatedDevices.Count -gt 0) {
+        $HTMLBody += "<h3>Updated Devices</h3>"
+        $HTMLBody += "<table border='1' style='border-collapse: collapse; width: 100%;'>"
+        $HTMLBody += "<tr style='background-color: #f2f2f2;'>"
+        $HTMLBody += "<th style='padding: 8px; text-align: left;'>Device Name</th>"
+        $HTMLBody += "<th style='padding: 8px; text-align: left;'>Serial Number</th>"
+        $HTMLBody += "<th style='padding: 8px; text-align: left;'>Previous Value</th>"
+        $HTMLBody += "</tr>"
+        
+        foreach ($device in $updatedDevices) {
+            $HTMLBody += "<tr>"
+            $HTMLBody += "<td style='padding: 8px;'>$($device.DeviceName)</td>"
+            $HTMLBody += "<td style='padding: 8px;'>$($device.SerialNumber)</td>"
+            $HTMLBody += "<td style='padding: 8px;'>$($device.PreviousValue)</td>"
+            $HTMLBody += "</tr>"
+        }
+        
+        $HTMLBody += "</table>"
+    }
+    
+    # Add skipped devices section
+    if ($skippedDevices.Count -gt 0) {
+        $HTMLBody += "<h3>Skipped Devices</h3>"
+        $HTMLBody += "<table border='1' style='border-collapse: collapse; width: 100%;'>"
+        $HTMLBody += "<tr style='background-color: #f2f2f2;'>"
+        $HTMLBody += "<th style='padding: 8px; text-align: left;'>Device Name</th>"
+        $HTMLBody += "<th style='padding: 8px; text-align: left;'>Serial Number</th>"
+        $HTMLBody += "<th style='padding: 8px; text-align: left;'>Reason</th>"
+        $HTMLBody += "</tr>"
+        
+        foreach ($device in $skippedDevices) {
+            $HTMLBody += "<tr>"
+            $HTMLBody += "<td style='padding: 8px;'>$($device.DeviceName)</td>"
+            $HTMLBody += "<td style='padding: 8px;'>$($device.SerialNumber)</td>"
+            $HTMLBody += "<td style='padding: 8px;'>$($device.Reason)</td>"
+            $HTMLBody += "</tr>"
+        }
+        
+        $HTMLBody += "</table>"
+    }
+    
+    # Add error devices section
+    if ($errorDevices.Count -gt 0) {
+        $HTMLBody += "<h3>Devices with Errors</h3>"
+        $HTMLBody += "<table border='1' style='border-collapse: collapse; width: 100%;'>"
+        $HTMLBody += "<tr style='background-color: #f2f2f2;'>"
+        $HTMLBody += "<th style='padding: 8px; text-align: left;'>Device Name</th>"
+        $HTMLBody += "<th style='padding: 8px; text-align: left;'>Serial Number</th>"
+        $HTMLBody += "<th style='padding: 8px; text-align: left;'>Error</th>"
+        $HTMLBody += "</tr>"
+        
+        foreach ($device in $errorDevices) {
+            $HTMLBody += "<tr>"
+            $HTMLBody += "<td style='padding: 8px;'>$($device.DeviceName)</td>"
+            $HTMLBody += "<td style='padding: 8px;'>$($device.SerialNumber)</td>"
+            $HTMLBody += "<td style='padding: 8px;'>$($device.Error)</td>"
+            $HTMLBody += "</tr>"
+        }
+        
+        $HTMLBody += "</table>"
+    }
+    
+    # Send email
+    $message = @{
+        subject      = "[Automated Report] Device Serial Number Sync - $tenantDisplayName"
+        body         = @{
+            contentType = "HTML"
+            content     = $HTMLBody
+        }
+        toRecipients = @(
+            @{
+                emailAddress = @{
+                    address = $sendReportTo
+                }
+            }
+        )
+    }
+    
+    Write-Output "Sending report to '$sendReportTo'..."
+    try {
+        Invoke-RjRbRestMethodGraph -Resource "/users/$sendReportFrom/sendMail" -Method POST -Body @{ message = $message } -ContentType "application/json" | Out-Null
+        Write-Output "Report successfully sent to '$sendReportTo'."
+    }
+    catch {
+        Write-Output "Error sending email: $_"
+        Write-RjRbLog -Message "Error sending email: $_" -Verbose
+    }
+}
+
+Write-Output "## Operation completed."


### PR DESCRIPTION
- Add runbook in Org/Devices:
  - "Delete stale devices (scheduled)"
    - Scheduled deletion of stale devices based on last activity date and platform.
    - Can be scheduled to run automatically and send a report via email.
  - "List stale devices (scheduled)"
    - Scheduled report of stale devices based on last activity date and platform.
    - Automatically sends a report via email.
  - "Sync device serial numbers to Entra ID (scheduled)"
    - Syncs serial numbers from Intune devices to Entra ID device extension attributes.
    - Helps maintain consistency between Intune and Entra ID device records.