### PR TITLE
Add scripts and permissions for managing application registrations in…

### DIFF
--- a/org/security/add-application-registration.permissions.json
+++ b/org/security/add-application-registration.permissions.json
@@ -1,0 +1,15 @@
+{
+    "Permissions": [
+        {
+            "Name": "Microsoft Graph",
+            "Id": "00000003-0000-0000-c000-000000000000",
+            "AppRoleAssignments": [
+                "Application.ReadWrite.All",
+                "Organization.Read.All",
+                "Group.ReadWrite.All"
+            ]
+        }
+    ],
+    "Roles": [],
+    "ManualPermissions": []
+}

--- a/org/security/add-application-registration.ps1
+++ b/org/security/add-application-registration.ps1
@@ -1,0 +1,480 @@
+<#
+
+.SYNOPSIS
+    Add an application registration to Azure AD
+
+.DESCRIPTION
+    This script creates a new application registration in Azure Active Directory (Entra ID) with comprehensive configuration options.
+    
+    The script validates input parameters, prevents duplicate application creation, and provides comprehensive logging
+    throughout the process. For SAML applications, it automatically configures reply URLs, sign-on URLs, logout URLs,
+    and certificate expiry notifications.
+
+.INPUTS
+    RunbookCustomization: {
+    "Parameters": {
+        "signInAudience": {
+            "Hide": true
+        },
+        "CallerName": {
+            "Hide": true
+        },
+        "ApplicationName": {
+            "DisplayName": "Application Name",
+            "Hide": false
+        },
+        "RedirectURI": {
+            "DisplayName": "Redirect URI (Optional)",
+            "Default": "None",
+            "Select": {
+                "Options": [
+                        {
+                        "Display": "None",
+                        "ParameterValue": "None",
+                        "Customization": {
+                            "Default": {
+                                        "EnableSAML": false
+                            },
+                            "Hide": [
+                                "webRedirectURI",
+                                "publicClientRedirectURI",
+                                "spaRedirectURI",
+                                "EnableSAML",
+                                "SAMLReplyURL",
+                                "SAMLSignOnURL",
+                                "SAMLLogoutURL",
+                                "SAMLIdentifier",
+                                "SAMLRelayState",
+                                "SAMLExpiryNotificationEmail",
+                                "SAMLCertificateLifeYears"
+                            ]
+                        }
+                        },
+                        {
+                            "Display": "Web",
+                            "ParameterValue": "Web",
+                            "Customization": {
+                                "Default": {
+                                        "EnableSAML": false
+                                },
+                                "Hide": [
+                                    "publicClientRedirectURI",
+                                    "spaRedirectURI",
+                                    "EnableSAML",
+                                    "SAMLReplyURL",
+                                    "SAMLSignOnURL",
+                                    "SAMLLogoutURL",
+                                    "SAMLIdentifier",
+                                    "SAMLRelayState",
+                                    "SAMLExpiryNotificationEmail",
+                                    "SAMLCertificateLifeYears"
+                                ]
+                            }
+                        },
+                        {
+                            "Display": "SAML",
+                            "ParameterValue": "SAML",
+                            "Customization": {
+                                "Default": {
+                                        "EnableSAML": true
+                                },
+                                "Hide": [
+                                    "webRedirectURI",
+                                    "publicClientRedirectURI",
+                                    "spaRedirectURI"
+                                ]
+                            }
+                        },
+                        {
+                            "Display": "Public client/native (mobile & desktop)",
+                            "ParameterValue": "PublicClient",
+                            "Customization": {
+                                "Default": {
+                                        "EnableSAML": false
+                                },
+                                "Hide": [
+                                    "webRedirectURI",
+                                    "spaRedirectURI",
+                                    "EnableSAML",
+                                    "SAMLReplyURL",
+                                    "SAMLSignOnURL",
+                                    "SAMLLogoutURL",
+                                    "SAMLIdentifier",
+                                    "SAMLRelayState",
+                                    "SAMLExpiryNotificationEmail",
+                                    "SAMLCertificateLifeYears"
+                                ]
+                            }
+                        },
+                        {
+                            "Display": "Single-page application (SPA)",
+                            "ParameterValue": "SPA",
+                            "Customization": {
+                                "Hide": [
+                                    "webRedirectURI",
+                                    "publicClientRedirectURI",
+                                    "EnableSAML",
+                                    "SAMLReplyURL",
+                                    "SAMLSignOnURL",
+                                    "SAMLLogoutURL",
+                                    "SAMLIdentifier",
+                                    "SAMLRelayState",
+                                    "SAMLExpiryNotificationEmail",
+                                    "SAMLCertificateLifeYears"
+                                ]
+                            }
+                        }
+                ],
+                "ShowValue": false
+            }
+        },
+        "webRedirectURI": {
+            "DisplayName": "Web Redirect URI e.g. https://myapp.com/auth (semicolon-separated for multiple)",
+            "Hide": false
+        },
+        "publicClientRedirectURI": {
+            "DisplayName": "Public client/native Redirect URI e.g. myapp://auth (semicolon-separated for multiple)",
+            "Hide": false
+        },
+        "spaRedirectURI": {
+            "DisplayName": "Single-page application (SPA) Redirect URI e.g. https://myapp.com (semicolon-separated for multiple)",
+            "Hide": false
+        },
+        "EnableSAML":{
+            "Hide": false
+        },
+        "SAMLReplyURL":{
+            "Hide": false
+        },
+        "SAMLSignOnURL":{
+            "Hide": false
+        },
+        "SAMLLogoutURL":{
+            "Hide": false
+        },
+        "SAMLIdentifier":{
+            "Hide": false
+        },
+        "SAMLRelayState":{
+            "Hide": false
+        },
+        "SAMLExpiryNotificationEmail":{
+            "Hide": false
+        },
+        "SAMLCertificateLifeYears":{
+            "Hide": false
+        },
+        "isApplicationVisible":{
+            "DisplayName": "Application visible in My Apps portal",
+            "Hide": false
+        },
+        "UserAssignmentRequired":{
+            "DisplayName": "User assignment required",
+            "Hide": false
+        },
+        "groupAssignmentPrefix":{
+            "DisplayName": "Group assignment prefix (Only necessary when User assignment required)",
+            "Hide": false
+        },
+        "implicitGrantAccessTokens":{
+            "DisplayName": "Enable implicit grant for access tokens",
+            "Hide": false
+        },
+        "implicitGrantIDTokens":{
+            "DisplayName": "Enable implicit grant for ID tokens",
+            "Hide": false
+        }
+    }
+}
+#>
+
+#Requires -Modules @{ModuleName = "RealmJoin.RunbookHelper"; ModuleVersion = "0.8.4" }
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $ApplicationName,
+    [string] $RedirectURI, # Only for UI used
+    [string] $signInAudience = "AzureADMyOrg",
+    [string] $webRedirectURI = "",
+    [string] $spaRedirectURI = "",
+    [string] $publicClientRedirectURI = "",
+    [bool] $EnableSAML = $false,
+    [String] $SAMLReplyURL = "",
+    [String] $SAMLSignOnURL = "",
+    [String] $SAMLLogoutURL = "",
+    [String] $SAMLIdentifier = "",
+    [String] $SAMLRelayState = "",
+    [String] $SAMLExpiryNotificationEmail = "",
+    [int] $SAMLCertificateLifeYears = 3,
+    [bool] $isApplicationVisible = $true,
+    [bool] $UserAssignmentRequired = $false,
+    [String] $groupAssignmentPrefix = "col - Entra - users - ",
+    [bool] $implicitGrantAccessTokens = $false,
+    [bool] $implicitGrantIDTokens = $false,
+    # CallerName is tracked purely for auditing purposes
+    [Parameter(Mandatory = $true)]
+    [string] $CallerName
+)
+
+Write-RjRbLog -Message "Caller: '$CallerName'" -Verbose
+
+Connect-RjRbGraph
+
+$ApplicationFullName = $ApplicationName
+
+# Check if an application with the same name already exists
+$existingApp = Invoke-RjRbRestMethodGraph -Method GET -Resource "/applications" -OdFilter "displayName eq '$ApplicationFullName'" -errorAction SilentlyContinue
+
+if ($existingApp) {
+    "## Application '$ApplicationFullName' already exists, id: $($existingApp.id)"
+    "## Stopping"
+    throw ("Application already exists")
+}
+
+$body = @{
+    "displayName"    = $ApplicationFullName
+    "signInAudience" = $signInAudience
+    "tags"           = @(
+        "WindowsAzureActiveDirectoryIntegratedApp"
+    )
+}
+
+if ($isApplicationVisible -eq $false) {
+    $body["tags"] += "HideApp"
+}
+
+$webRedirectURIs = @()
+if ($webRedirectURI) {
+    $webRedirectURIs += $webRedirectURI.Split(";").Trim()
+}
+$spaRedirectURIs = @()
+if ($spaRedirectURI) {
+    $spaRedirectURIs += $spaRedirectURI.Split(";").Trim()
+}
+$publicClientRedirectURIs = @()
+if ($publicClientRedirectURI) {
+    $publicClientRedirectURIs += $publicClientRedirectURI.Split(";").Trim()
+}
+
+if (($webRedirectURIs.count -gt 0) -or ($EnableSAML -and ($SAMLReplyURL.count -gt 0))) {
+    if ($SAMLReplyURL) {
+        $webRedirectURIs = @($SAMLReplyURL)
+    }
+    else {
+        "## Web redirect URI / SAML Reply URL must be specified for SAML applications."
+        "## Stopping"
+        throw ("Web redirect URI must be specified for SAML applications")
+    }
+}
+
+$body[“web"] = @{}
+
+# Set the redirect URIs if Web redirect URIs are specified
+$redirects = @()
+if ($webRedirectURIs.count -gt 0) {
+    $redirects = @($webRedirectURIs)
+    if ($EnableSAML -and $SAMLReplyURL -and ($redirects -notcontains $SAMLReplyURL)) {
+        $redirects += $SAMLReplyURL
+    }
+    $body["web"]["redirectUris"] = $redirects
+}
+
+$body["web"]["implicitGrantSettings"] = @{
+    "enableAccessTokenIssuance" = $implicitGrantAccessTokens
+    "enableIdTokenIssuance"     = $implicitGrantIDTokens
+}
+
+if ($spaRedirectURIs.Count -gt 0) {
+    $body["spa"] = @{
+        redirectUris = $spaRedirectURIs
+    }
+}
+
+if ($publicClientRedirectURIs.Count -gt 0) {
+    $body["publicClient"] = @{
+        redirectUris = $publicClientRedirectURIs
+    }
+}
+
+if ($EnableSAML -and (-not $SAMLReplyURL)) {
+    if ($publicClientRedirectURIs.Count -gt 0) {
+        $SAMLReplyURL = $publicClientRedirectURI[0]
+    }
+    elseif ($webRedirectURIs.Count -gt 0) {
+        $SAMLReplyURL = $webRedirectURI[0]
+    }
+    elseif ($spaRedirectURIs.Count -gt 0) {
+        $SAMLReplyURL = $spaRedirectURI[0]
+    } 
+}
+
+if ($EnableSAML -and (-not $SAMLReplyURL)) {
+    "## SAML Reply URL must be specified for SAML applications."
+    "## Stopping"
+    throw ("SAML Reply URL must be specified for SAML applications")
+}
+
+# Add default permissions
+$body["requiredResourceAccess"] = @(
+    @{
+        "resourceAppId"  = "00000003-0000-0000-c000-000000000000"
+        "resourceAccess" = @(
+            @{
+                "id"   = "e1fe6dd8-ba31-4d61-89e7-88639da4683d"
+                "type" = "Scope"
+            }
+            @{
+                "id"   = "37f7f235-527c-4136-accd-4a02d197296e"
+                "type" = "Scope"
+            }
+            @{
+                "id"   = "14dad69e-099b-42c9-810b-d002981feec1"
+                "type" = "Scope"
+            }
+            @{
+                "id"   = "7427e0e9-2fba-42fe-b0c0-848c9e6a8182"
+                "type" = "Scope"
+            }
+        )
+    }
+)
+
+$tenantId = (invoke-RjRbRestMethodGraph -Resource "/organization").id
+
+$resultApp = Invoke-RjRbRestMethodGraph -Resource "/applications" -Method POST -Body $body
+""
+"## Application '$ApplicationFullName' created, AppId: $($resultApp.appId), TenantId: $tenantId"
+
+"## Wait for the application to be ready"
+Start-Sleep -Seconds 20
+
+$body = @{
+    "appId" = $resultApp.appId
+}
+
+if ($EnableSAML) {
+    $body["preferredSingleSignOnMode"] = "saml"
+    
+    $body["samlSingleSignOnSettings"] = @{
+        "relayState" = $SAMLRelayState
+    }
+
+    #$body["replyUrls"] = @(
+    #    $SAMLReplyURL
+    #)
+    if ($SAMLSignOnURL) { 
+        $body["loginUrl"] = $SAMLSignOnURL 
+    }
+}
+
+if ($UserAssignmentRequired) {
+    $body["appRoleAssignmentRequired"] = $true
+}
+
+
+$resultSvcPrincipal = Invoke-RjRbRestMethodGraph -Resource "/servicePrincipals" -Method POST -Body $body
+"## Service Principal for '$ApplicationFullName' created, id: $($resultSvcPrincipal.id)"
+
+"## Wait for the Service Principal to be ready"
+Start-Sleep -Seconds 20
+
+if ($EnableSAML) {
+    if (-not $SAMLIdentifier) {
+        $SAMLIdentifier = "urn:app:$($resultApp.appId)"
+    }
+    else {
+        $SAMLIdentifier = $SAMLIdentifier.trim().trimend('/')
+    }
+
+    "## Update the application object with the SAML2 settings"
+    $body = @{
+        "tags" = $resultApp.tags
+    }
+    $body["tags"] += "WindowsAzureActiveDirectoryCustomSingleSignOnApplication"
+    $body["identifierUris"] = @(
+        $SAMLIdentifier
+    )
+    if ($SAMLLogoutURL) {
+        $body["web"] = @{
+            "logoutUrl" = $SAMLLogoutURL
+        } 
+    }
+    Invoke-RjRbRestMethodGraph -Resource "/applications/$($resultApp.id)" -Method PATCH -Body $body | Out-Null
+
+    "## Wait for the application to be ready"
+    Start-Sleep -Seconds 20
+
+    "## Update the service principal object with the SAML2 settings"
+    $body = @{}
+    $body["servicePrincipalNames"] = @(
+        $SAMLIdentifier,
+        $resultApp.appId
+    )
+
+    Invoke-RjRbRestMethodGraph -Resource "/servicePrincipals/$($resultSvcPrincipal.id)" -Method PATCH -Body $body | Out-Null
+
+    # Create a token signing certificate
+    $certname = "CN=Microsoft Azure Federated SSO Certificate"
+    $endDate = (Get-Date).AddYears($SAMLCertificateLifeYears).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    $certBody = @{
+        "displayName" = $certname
+        "endDateTime" = $endDate
+    }
+    $certResult = Invoke-RjRbRestMethodGraph -Resource "/servicePrincipals/$($resultSvcPrincipal.id)/addTokenSigningCertificate" -Method POST -Body $certBody
+    "## Token signing certificate created."
+    ""
+    "## DEBUG - Print the certificate (public key))"
+    $certResult | Format-List | Out-String
+    ""
+
+    if ($SAMLExpiryNotificationEmail) {
+        "## Update the certificate expiry notification email to '$SAMLExpiryNotificationEmail'"
+        $body = @{
+            "notificationEmailAddresses" = @(
+                $SAMLExpiryNotificationEmail
+            )
+        }
+        Invoke-RjRbRestMethodGraph -Resource "/servicePrincipals/$($resultSvcPrincipal.id)" -Method PATCH -Body $body | Out-Null
+    }
+}
+
+[string]$shortAppName = $ApplicationFullName -replace " \| ", "-" -replace "\|", "-" # -replace " ", "-" -replace "[()]", ""
+
+[string]$mailnickname = $ApplicationName -replace " \| ", "-" -replace "\|", "-" -replace " ", "-" -replace "[()]", ""
+if ($mailnickname.Length -gt 25) {
+    $mailnickname = $mailnickname.Substring(0, 24)
+}
+
+if ($UserAssignmentRequired) {
+    # Create an EntraID group for the application
+    # Create a valid mailNickname by removing invalid characters (spaces, special chars)
+    $groupMailNickname = ($groupAssignmentPrefix + $mailnickname) -replace "[^a-zA-Z0-9\-]", "" -replace "^-+", "" -replace "-+$", ""
+    # Ensure mailNickname doesn't exceed 64 characters and doesn't start/end with dash
+    if ($groupMailNickname.Length -gt 64) {
+        $groupMailNickname = $groupMailNickname.Substring(0, 63)
+    }
+    # Remove trailing dashes if any
+    $groupMailNickname = $groupMailNickname -replace "-+$", ""
+    
+    $groupBody = @{
+        "displayName"     = "$groupAssignmentPrefix$shortAppName"
+        "description"     = "Users of $ApplicationFullName"
+        "mailEnabled"     = $false
+        "mailNickname"    = $groupMailNickname
+        "securityEnabled" = $true
+    }
+    $resultGroup = Invoke-RjRbRestMethodGraph -Resource "/groups" -Method POST -Body $groupBody
+    "## Group '$($resultGroup.displayName)' created, id: $($resultGroup.id)"
+
+    # Add the group to the application
+    $groupAppRoleBody = @{
+        "appRoleId"   = "00000000-0000-0000-0000-000000000000"
+        "principalId" = $resultGroup.id
+        "resourceId"  = $resultSvcPrincipal.id
+    }
+    $resultGroupAppRole = Invoke-RjRbRestMethodGraph -Resource "/servicePrincipals/$($resultSvcPrincipal.id)/appRoleAssignedTo" -Method POST -Body $groupAppRoleBody
+    "## Group '$($resultGroup.displayName)' added to application '$ApplicationFullName'"
+}
+
+
+"## Application registration successfully created."

--- a/org/security/delete-application-registration.permissions.json
+++ b/org/security/delete-application-registration.permissions.json
@@ -1,0 +1,14 @@
+{
+    "Permissions": [
+        {
+            "Name": "Microsoft Graph",
+            "Id": "00000003-0000-0000-c000-000000000000",
+            "AppRoleAssignments": [
+                "Application.ReadWrite.All",
+                "Group.ReadWrite.All"
+            ]
+        }
+    ],
+    "Roles": [],
+    "ManualPermissions": []
+}

--- a/org/security/delete-application-registration.ps1
+++ b/org/security/delete-application-registration.ps1
@@ -1,0 +1,72 @@
+<#
+
+.SYNOPSIS
+    Delete an application registration from Azure AD
+
+.DESCRIPTION
+    This script safely removes an application registration and its associated service principal from Azure Active Directory (Entra ID).
+    
+    This script is the counterpart to the add-application-registration script and ensures
+    proper cleanup of all resources created during application registration.
+
+.INPUTS
+    RunbookCustomization: {
+        "Parameters": {
+            "CallerName": {
+                "Hide": true
+            }
+        }
+    }
+#>
+
+#Requires -Modules @{ModuleName = "RealmJoin.RunbookHelper"; ModuleVersion = "0.8.4" }
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $ClientId,
+    # CallerName is tracked purely for auditing purposes
+    [Parameter(Mandatory = $true)]
+    [string] $CallerName
+)
+
+Write-RjRbLog -Message "Caller: '$CallerName'" -Verbose
+
+Connect-RjRbGraph
+
+# Check if the application exists
+$existingApp = Invoke-RjRbRestMethodGraph -Method GET -Resource "/applications" -OdFilter "appId eq '$ClientId'" -ErrorAction SilentlyContinue
+
+if (-not $existingApp) {
+    "## Application with AppId '$ClientId' does not exist."
+    throw "Application with AppId '$ClientId' does not exist."
+}
+
+# Check if the service principal exists
+$existingServicePrincipal = Invoke-RjRbRestMethodGraph -Method GET -Resource "/servicePrincipals" -OdFilter "appId eq '$ClientId'" -ErrorAction SilentlyContinue
+
+$assignedGroups = @()
+if ($existingServicePrincipal) {
+    # Check if a group is assigned to the application. Save the group for later.
+    $existingAppRoleAssignment = Invoke-RjRbRestMethodGraph -Method GET -Resource "/servicePrincipals/$($existingServicePrincipal.id)/appRoleAssignedTo" -ErrorAction SilentlyContinue
+    $existingAppRoleAssignment | ForEach-Object {
+        if ($_.principalType -eq "Group") {
+            #$existingGroup = Invoke-RjRbRestMethodGraph -Method GET -Resource "/groups/$($_.principalId)" -ErrorAction SilentlyContinue
+            $assignedGroups += $existingAppRoleAssignment
+        }
+        
+    }
+}
+
+"## Deleting the application"
+"## '$ClientId'"
+Invoke-RjRbRestMethodGraph -Method DELETE -Resource "/applications/$($existingApp.id)" | Out-Null
+
+if ($assignedGroups.count -gt 0) {
+    "## Deleting assigned groups"    
+    $assignedGroups | ForEach-Object {
+        "## - '$($_.principalDisplayName)'"
+        Invoke-RjRbRestMethodGraph -Method DELETE -Resource "/groups/$($_.principalId)" | Out-Null
+    }
+}
+    
+"## Application deleted successfully"

--- a/org/security/update-application-registration.permissions.json
+++ b/org/security/update-application-registration.permissions.json
@@ -1,0 +1,15 @@
+{
+    "Permissions": [
+        {
+            "Name": "Microsoft Graph",
+            "Id": "00000003-0000-0000-c000-000000000000",
+            "AppRoleAssignments": [
+                "Application.ReadWrite.All",
+                "Organization.Read.All",
+                "Group.ReadWrite.All"
+            ]
+        }
+    ],
+    "Roles": [],
+    "ManualPermissions": []
+}

--- a/org/security/update-application-registration.ps1
+++ b/org/security/update-application-registration.ps1
@@ -1,0 +1,497 @@
+<#
+
+.SYNOPSIS
+    Update an application registration in Azure AD
+
+.DESCRIPTION
+    This script modifies an existing application registration in Azure Active Directory (Entra ID) with comprehensive configuration updates.
+    
+    The script intelligently determines what changes need to be applied by comparing current settings
+    with requested parameters, ensuring only necessary updates are performed. It maintains backward
+    compatibility while supporting modern authentication patterns and security requirements.
+
+.INPUTS
+    RunbookCustomization: {
+    "Parameters": {
+        "signInAudience": {
+            "Hide": true
+        },
+        "CallerName": {
+            "Hide": true
+        },
+        "RedirectURI": {
+            "DisplayName": "Redirect URI (Optional)",
+            "Default": "None",
+            "Select": {
+                "Options": [
+                        {
+                        "Display": "None",
+                        "ParameterValue": "None",
+                        "Customization": {
+                            "Default": {
+                                        "EnableSAML": false
+                            },
+                            "Hide": [
+                                "webRedirectURI",
+                                "publicClientRedirectURI",
+                                "spaRedirectURI",
+                                "EnableSAML",
+                                "SAMLReplyURL",
+                                "SAMLSignOnURL",
+                                "SAMLLogoutURL",
+                                "SAMLIdentifier",
+                                "SAMLRelayState",
+                                "SAMLExpiryNotificationEmail"
+                            ]
+                        }
+                        },
+                        {
+                            "Display": "Web",
+                            "ParameterValue": "Web",
+                            "Customization": {
+                                "Default": {
+                                        "EnableSAML": false
+                                },
+                                "Hide": [
+                                    "publicClientRedirectURI",
+                                    "spaRedirectURI",
+                                    "EnableSAML",
+                                    "SAMLReplyURL",
+                                    "SAMLSignOnURL",
+                                    "SAMLLogoutURL",
+                                    "SAMLIdentifier",
+                                    "SAMLRelayState",
+                                    "SAMLExpiryNotificationEmail"
+                                ]
+                            }
+                        },
+                        {
+                            "Display": "SAML",
+                            "ParameterValue": "SAML",
+                            "Customization": {
+                                "Default": {
+                                        "EnableSAML": true
+                                },
+                                "Hide": [
+                                    "webRedirectURI",
+                                    "publicClientRedirectURI",
+                                    "spaRedirectURI"
+                                ]
+                            }
+                        },
+                        {
+                            "Display": "Public client/native (mobile & desktop)",
+                            "ParameterValue": "PublicClient",
+                            "Customization": {
+                                "Default": {
+                                        "EnableSAML": false
+                                },
+                                "Hide": [
+                                    "webRedirectURI",
+                                    "spaRedirectURI",
+                                    "EnableSAML",
+                                    "SAMLReplyURL",
+                                    "SAMLSignOnURL",
+                                    "SAMLLogoutURL",
+                                    "SAMLIdentifier",
+                                    "SAMLRelayState",
+                                    "SAMLExpiryNotificationEmail"
+                                ]
+                            }
+                        },
+                        {
+                            "Display": "Single-page application (SPA)",
+                            "ParameterValue": "SPA",
+                            "Customization": {
+                                "Hide": [
+                                    "webRedirectURI",
+                                    "publicClientRedirectURI",
+                                    "EnableSAML",
+                                    "SAMLReplyURL",
+                                    "SAMLSignOnURL",
+                                    "SAMLLogoutURL",
+                                    "SAMLIdentifier",
+                                    "SAMLRelayState",
+                                    "SAMLExpiryNotificationEmail"
+                                ]
+                            }
+                        }
+                ],
+                "ShowValue": false
+            }
+        },
+        "webRedirectURI": {
+            "DisplayName": "Web Redirect URI e.g. https://myapp.com/auth (semicolon-separated for multiple)",
+            "Hide": false
+        },
+        "publicClientRedirectURI": {
+            "DisplayName": "Public client/native Redirect URI e.g. myapp://auth (semicolon-separated for multiple)",
+            "Hide": false
+        },
+        "spaRedirectURI": {
+            "DisplayName": "Single-page application (SPA) Redirect URI e.g. https://myapp.com (semicolon-separated for multiple)",
+            "Hide": false
+        },
+        "EnableSAML":{
+            "Hide": false
+        },
+        "SAMLReplyURL":{
+            "Hide": false
+        },
+        "SAMLSignOnURL":{
+            "Hide": false
+        },
+        "SAMLLogoutURL":{
+            "Hide": false
+        },
+        "SAMLIdentifier":{
+            "Hide": false
+        },
+        "SAMLRelayState":{
+            "Hide": false
+        },
+        "SAMLExpiryNotificationEmail":{
+            "Hide": false
+        },
+        "isApplicationVisible":{
+            "DisplayName": "Application visible in My Apps portal",
+            "Hide": false
+        },
+        "UserAssignmentRequired":{
+            "DisplayName": "User assignment required",
+            "Hide": false
+        },
+        "groupAssignmentPrefix":{
+            "DisplayName": "Group assignment prefix (Only necessary when User assignment required)",
+            "Hide": false
+        },
+        "implicitGrantAccessTokens":{
+            "DisplayName": "Enable implicit grant for access tokens",
+            "Hide": false
+        },
+        "implicitGrantIDTokens":{
+            "DisplayName": "Enable implicit grant for ID tokens",
+            "Hide": false
+        }
+    }
+}
+#>
+
+#Requires -Modules @{ModuleName = "RealmJoin.RunbookHelper"; ModuleVersion = "0.8.4" }
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $ClientId,
+    [string] $RedirectURI, # Only for UI used
+    [string] $webRedirectURI = "",
+    [string] $publicClientRedirectURI = "",
+    [string] $spaRedirectURI = "",
+    [bool] $EnableSAML = $false,
+    [String] $SAMLReplyURL = "",
+    [String] $SAMLSignOnURL = "",
+    [String] $SAMLLogoutURL = "",
+    [String] $SAMLIdentifier = "",
+    [String] $SAMLRelayState = "",
+    [String] $SAMLExpiryNotificationEmail = "",
+    [bool] $isApplicationVisible = $true,
+    [bool] $UserAssignmentRequired = $false,
+    [String] $groupAssignmentPrefix = "col - Entra - users - ",
+    [bool] $implicitGrantAccessTokens = $false,
+    [bool] $implicitGrantIDTokens = $false,
+    [bool] $disableImplicitGrant = $false,
+    # CallerName is tracked purely for auditing purposes
+    [Parameter(Mandatory = $true)]
+    [string] $CallerName
+)
+
+Write-RjRbLog -Message "Caller: '$CallerName'" -Verbose
+
+Connect-RjRbGraph
+
+# Check if the application exists
+$existingApp = Invoke-RjRbRestMethodGraph -Method GET -Resource "/applications" -OdFilter "appId eq '$ClientId'" -errorAction SilentlyContinue
+
+if (-not $existingApp) {
+    "## Application with '$ClientId' does not exists."
+    throw "Application with '$ClientId' does not exists. Stopping."
+}
+
+# Check if the service principal exists
+$existingSvcPrincipal = Invoke-RjRbRestMethodGraph -Method GET -Resource "/servicePrincipals" -OdFilter "appId eq '$ClientId'" -errorAction SilentlyContinue
+
+if (-not $existingSvcPrincipal) {
+    "## Service Principal for ClientId '$ClientId' does not exists."
+    throw "Service Principal for ClientId '$ClientId' does not exists. Stopping."
+}
+
+$webRedirectURIs = @()
+if ($webRedirectURI) {
+    $webRedirectURIs += $webRedirectURI.Split(";").Trim()
+}
+$spaRedirectURIs = @()
+if ($spaRedirectURI) {
+    $spaRedirectURIs += $spaRedirectURI.Split(";").Trim()
+}
+$publicClientRedirectURIs = @()
+if ($publicClientRedirectURI) {
+    $publicClientRedirectURIs += $publicClientRedirectURI.Split(";").Trim()
+}
+
+if (($webRedirectURIs.count -gt 0) -or ($EnableSAML -and ($SAMLReplyURL.count -gt 0))) {
+    if ($SAMLReplyURL) {
+        $webRedirectURIs = @($SAMLReplyURL)
+    }
+    else {
+        "## Web redirect URI / SAML Reply URL must be specified for SAML applications."
+        "## Stopping"
+        throw ("Web redirect URI must be specified for SAML applications")
+    }
+}
+
+if ($EnableSAML -and (-not $SAMLReplyURL)) {
+    if ($publicClientRedirectURIs.Count -gt 0) {
+        $SAMLReplyURL = $publicClientRedirectURI[0]
+    }
+    elseif ($webRedirectURIs.Count -gt 0) {
+        $SAMLReplyURL = $webRedirectURI[0]
+    }
+    elseif ($spaRedirectURIs.Count -gt 0) {
+        $SAMLReplyURL = $spaRedirectURI[0]
+    } 
+}
+
+if ($EnableSAML -and (-not $SAMLReplyURL)) {
+    "## SAML Reply URL must be specified for SAML applications."
+    "## Stopping"
+    throw ("SAML Reply URL must be specified for SAML applications")
+}
+
+if ($SAMLIdentifier) {
+    $SAMLIdentifier = $SAMLIdentifier.trim().trimend('/')
+}
+
+# Make sure early that SAML is enabled on the service principal, if required.
+if ($EnableSAML) {
+    if ($existingSvcPrincipal.preferredSingleSignOnMode -ne "saml") {
+        $body = @{}
+
+        "## Updating preferredSingleSignOnMode to 'saml'"
+        $body["preferredSingleSignOnMode"] = "saml"
+
+        invoke-RjRbRestMethodGraph -Resource "/servicePrincipals/$($existingSvcPrincipal.id)" -Method PATCH -Body $body | Out-Null
+        "## Waiting 20 seconds for changes to propagate to the application"
+    }
+}
+
+$body = @{}
+$web = @{}
+
+# Set the redirect URIs if Web redirect URIs are specified
+$redirects = @()
+if ($webRedirectURIs.count -gt 0) {
+    $redirects = @($webRedirectURIs)
+    if ($EnableSAML -and $SAMLReplyURL -and ($redirects -notcontains $SAMLReplyURL)) {
+        $redirects += $SAMLReplyURL
+    }
+    $web["redirectUris"] = $redirects
+} 
+
+if ($disableImplicitGrant) {
+    $web["implicitGrantSettings"] = @{
+        "enableAccessTokenIssuance" = $false
+        "enableIdTokenIssuance"     = $false
+    }
+}
+else {
+    $web["implicitGrantSettings"] = @{
+        "enableAccessTokenIssuance" = $existingApp.web.implicitGrantSettings.enableAccessTokenIssuance -or $implicitGrantAccessTokens
+        "enableIdTokenIssuance"     = $existingApp.web.implicitGrantSettings.enableIdTokenIssuance -or $implicitGrantIDTokens
+    }    
+}
+
+if ($spaRedirectURI) {
+    "## Updating spa redirect URIs"
+    $body["spa"] = @{
+        "redirectUris" = $spaRedirectURis
+    } 
+}
+
+if ($publicClientRedirectURI) { 
+    "## Updating Public Client redirect URIs"
+    $body["publicClient"] = @{
+        "redirectUris" = $publicClientRedirectURIs
+    } 
+}
+
+$body["tags"] = [array]($existingApp.tags)
+
+if ($EnableSAML) {
+    if ($existingApp.signInAudience -ne "AzureADMyOrg") {
+        "## Updating signInAudience to 'AzureADMyOrg'"
+        $body["signInAudience"] = "AzureADMyOrg"
+    }
+    if ($body["tags"] -notcontains "WindowsAzureActiveDirectoryCustomSingleSignOnApplication") {
+        "## Updating tags to include 'WindowsAzureActiveDirectoryCustomSingleSignOnApplication'"
+        $body["tags"] = [array]($body["tags"] + "WindowsAzureActiveDirectoryCustomSingleSignOnApplication")
+    }
+    if ($SAMLLogoutURL) {
+        $web["logoutUrl"] = $SAMLLogoutURL
+    } 
+    if ($SAMLIdentifier) {
+        "## Updating identifierUris to '$SAMLIdentifier'"
+        $body["identifierUris"] = @($SAMLIdentifier)
+    }
+}
+
+# Check if the application is visible
+if ($isApplicationVisible -and ($body["tags"] -contains "HideApp")) {
+    "## Making the application visible"
+    $body["tags"] = [array]($body["tags"] -ne "HideApp")
+}
+if (-not $isApplicationVisible -and ($body["tags"] -notcontains "HideApp")) {
+    "## Hiding the application"
+    $body["tags"] = [array]($body["tags"] + @("HideApp"))
+}
+
+if ($web.count -gt 0) {
+    $body["web"] = $web
+}
+
+if ($body.count -gt 0) {
+
+    Invoke-RjRbRestMethodGraph -Resource "/applications/$($existingApp.id)" -Method PATCH -Body $body | Out-Null
+    "## Application updated."
+    "## Waiting 20 seconds for changes to propagate to the service principal"
+    Start-Sleep -Seconds 20
+}
+
+$body = @{}
+
+# Check if SAML Settings are correct for the service principal
+if ($EnableSAML) {
+    $resultSvcPrincipal = Invoke-RjRbRestMethodGraph -Resource "/servicePrincipals/$($existingSvcPrincipal.id)" -Method GET
+    if ($SAMLReplyURL) {
+        if ($resultSvcPrincipal.replyUrls -notcontains $SAMLReplyURL) {
+            "## Updating SAML Reply URL to '$SAMLReplyURL'"
+            $body["replyUrls"] = @($SAMLReplyURL)
+        }
+    }
+    if ($SAMLRelayState -and ($resultSvcPrincipal.samlSingleSignOnSettings.relayState -ne $SAMLRelayState)) {
+        "## Updating SAML Relay State to '$SAMLRelayState'"
+        $body["samlSingleSignOnSettings"] = @{
+            "relayState" = $SAMLRelayState
+        }
+    }
+    if ($SAMLSignOnURL -and ($resultSvcPrincipal.loginUrl -ne $SAMLSignOnURL)) {
+        "## Updating SAML Sign On URL to '$SAMLSignOnURL'"
+        $body["loginUrl"] = $SAMLSignOnURL
+    }
+    if ($SAMLIdentifier -and ($resultSvcPrincipal.servicePrincipalNames -notcontains $SAMLIdentifier)) {
+        "## Updating ServicePrincipalNames to include SAML Identifier '$SAMLIdentifier'"
+        $body["servicePrincipalNames"] = @(
+            $SAMLIdentifier,
+            $ClientId
+        )
+    }
+    if ($SAMLExpiryNotificationEmail -and ($resultSvcPrincipal.notificationEmailAddresses -notcontains $SAMLExpiryNotificationEmail)) {
+        "## Updating Notification Email to '$SAMLExpiryNotificationEmail'"
+        $body["notificationEmailAddresses"] = @($SAMLExpiryNotificationEmail) 
+    }
+
+    Invoke-RjRbRestMethodGraph -Resource "/servicePrincipals/$($resultSvcPrincipal.id)" -Method PATCH -Body $body | Out-Null
+    "## Service Principal updated."
+    "## Waiting 20 seconds for changes to propagate."
+    Start-Sleep -Seconds 20
+}
+
+if ($PSBoundParameters.Keys -contains "UserAssignmentRequired") {
+    if ($UserAssignmentRequired) {
+        # Check if the user assignment is required
+        $resultSvcPrincipal = Invoke-RjRbRestMethodGraph -Resource "/servicePrincipals/$($existingSvcPrincipal.id)" -Method GET
+        if ($resultSvcPrincipal.appRoleAssignmentRequired -ne $true) {
+            "## Updating appRoleAssignmentRequired to '$true'"
+            $body = @{
+                "appRoleAssignmentRequired" = $true
+            }
+
+            Invoke-RjRbRestMethodGraph -Resource "/servicePrincipals/$($resultSvcPrincipal.id)" -Method PATCH -Body $body | Out-Null
+        
+            $appRoleAssignments = Invoke-RjRbRestMethodGraph -Resource "/servicePrincipals/$($resultSvcPrincipal.id)/appRoleAssignedTo" -Method GET -errorAction SilentlyContinue
+            if (-not $appRoleAssignments) {
+                $ApplicationName = $existingApp.displayName
+                $ApplicationFullName = $ApplicationName
+    
+                [string]$shortAppName = $ApplicationFullName -replace " \| ", "-" -replace "\|", "-" # -replace " ", "-" -replace "[()]", ""
+    
+                [string]$mailnickname = $ApplicationName -replace " \| ", "-" -replace "\|", "-" -replace " ", "-" -replace "[()]", ""
+                if ($mailnickname.Length -gt 25) {
+                    $mailnickname = $mailnickname.Substring(0, 24)
+                }
+
+                # Create a valid mailNickname by removing invalid characters (spaces, special chars)
+                $groupMailNickname = ($groupAssignmentPrefix + $mailnickname) -replace "[^a-zA-Z0-9\-]", "" -replace "^-+", "" -replace "-+$", ""
+                # Ensure mailNickname doesn't exceed 64 characters and doesn't start/end with dash
+                if ($groupMailNickname.Length -gt 64) {
+                    $groupMailNickname = $groupMailNickname.Substring(0, 63)
+                }
+                # Remove trailing dashes if any
+                $groupMailNickname = $groupMailNickname -replace "-+$", ""
+
+                $groupBody = @{
+                    "displayName"     = "$groupAssignmentPrefix$shortAppName"
+                    "description"     = "Users of $ApplicationFullName"
+                    "mailEnabled"     = $false
+                    "mailNickname"    = $groupMailNickname
+                    "securityEnabled" = $true
+                }
+                $resultGroup = Invoke-RjRbRestMethodGraph -Resource "/groups" -Method POST -Body $groupBody
+                "## Group '$($resultGroup.displayName)' created, id: $($resultGroup.id)"
+            
+                # Add the group to the application
+                $groupAppRoleBody = @{
+                    "appRoleId"   = "00000000-0000-0000-0000-000000000000"
+                    "principalId" = $resultGroup.id
+                    "resourceId"  = $resultSvcPrincipal.id
+                }
+                $resultGroupAppRole = Invoke-RjRbRestMethodGraph -Resource "/servicePrincipals/$($resultSvcPrincipal.id)/appRoleAssignedTo" -Method POST -Body $groupAppRoleBody
+                "## Group '$($resultGroup.displayName)' added to application '$ApplicationFullName'"
+            }
+        }
+    }
+    else {
+        # If $UserAssignmentRequired=false
+        $resultSvcPrincipal = Invoke-RjRbRestMethodGraph -Resource "/servicePrincipals/$($existingSvcPrincipal.id)" -Method GET
+        if ($resultSvcPrincipal.appRoleAssignmentRequired -ne $false) {
+            "## Updating appRoleAssignmentRequired to '$false'"
+            $body = @{
+                "appRoleAssignmentRequired" = $false
+            }
+
+            Invoke-RjRbRestMethodGraph -Resource "/servicePrincipals/$($resultSvcPrincipal.id)" -Method PATCH -Body $body | Out-Null
+            "## Waiting 20 seconds for changes to propagate."
+            Start-Sleep -Seconds 20
+        }    
+    }
+}
+
+# refresh the service principal
+$existingSvcPrincipal = Invoke-RjRbRestMethodGraph -Method GET -Resource "/servicePrincipals" -OdFilter "appId eq '$ClientId'" -errorAction Stop
+
+# Check if the application is visible
+$body = @{}
+if ($isApplicationVisible -and ($existingSvcPrincipal.tags -contains "HideApp")) {
+    "## Making the application visible"
+    $body["tags"] = [array]($existingSvcPrincipal.tags -ne "HideApp")
+}
+if (-not $isApplicationVisible -and ($existingSvcPrincipal.tags -notcontains "HideApp")) {
+    "## Hiding the application"
+    $body["tags"] = [array]($existingSvcPrincipal.tags + @("HideApp"))
+}
+if ($body.count -gt 0) {
+
+    Invoke-RjRbRestMethodGraph -Resource "/servicePrincipals/$($existingSvcPrincipal.id)" -Method PATCH -Body $body | Out-Null
+    "## Service Principal updated."
+    "## Waiting 20 seconds for changes to propagate."
+    Start-Sleep -Seconds 20
+}
+


### PR DESCRIPTION
This pull request introduces new scripts and permission configuration files to manage Azure AD (Entra ID) application registrations, including adding, updating, and deleting applications. The changes ensure proper assignment and cleanup of permissions and resources associated with application registrations.

**New PowerShell script for application deletion:**

- Added `delete-application-registration.ps1`, a script that safely removes an application registration and its associated service principal from Azure AD, including cleanup of assigned groups.

**Permission configuration files for application registration management:**

- Added `add-application-registration.permissions.json` and `update-application-registration.permissions.json` to define required Microsoft Graph permissions for adding and updating application registrations, including `Application.ReadWrite.All`, `Organization.Read.All`, and `Group.ReadWrite.All`.
- Added `delete-application-registration.permissions.json` to specify the necessary permissions for deleting application registrations, requiring `Application.ReadWrite.All` and `Group.ReadWrite.All`.