### PR TITLE
Add error handling for access denied scenario in check updateble assets

### DIFF
--- a/device/general/check-updatable-assets.ps1
+++ b/device/general/check-updatable-assets.ps1
@@ -81,6 +81,10 @@ catch {
         Write-Output "- Status: Device is not onboarded / not found (404)."
         Write-RjRbLog -Message "- Error: $($errorResponse)" -Verbose
     }
+    elseif ($errorResponse -match '403') {
+        Write-Output "- Status can not be checked: Access denied (403). Please ensure RealmJoin has the required permissions."
+        Write-RjRbLog -Message "- Error: $($errorResponse)" -Verbose
+    }
     else {
         Write-Output "- Status: Device is not onboarded - see details in the following."
         Write-Output "- Error: $($errorResponse)"


### PR DESCRIPTION
This pull request adds improved error handling for permission issues when checking device status in the `device/general/check-updatable-assets.ps1` script. Specifically, it introduces a check for HTTP 403 errors and provides a clear message if access is denied.

Error handling improvements:

* Added a specific check for 403 errors to output a user-friendly message indicating access is denied and suggesting to check RealmJoin permissions. (`device/general/check-updatable-assets.ps1`)