### PR TITLE
Add runbook for reporting Entra Agent Identities without sponsors or owners, including detailed permissions and output structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # RealmJoin Runbooks Changelog
 
+## 2026-08-17
+
+- Add **Agent Identities Without Sponsor or Owner (Scheduled)** Runbook in Org/General
+  - Report active Entra Agent Identities without sponsors and/or owners through Microsoft Graph beta derived-type endpoints
+  - Label sponsorless identities as anomalies and ownerless identities as legitimate, and surface relationship lookup failures as unknown instead of false findings
+  - Enrich report rows with Agent Identity Blueprint details and support selectable report scopes plus optional inactive identities
+  - Note: reading the sponsors relationship currently requires `AgentIdentity.ReadWrite.All` because Microsoft Graph exposes no read-only application permission for that API
+
 ## 2026-08-13
 
 - Add customizable email branding to all 28 runbooks that send report or notification emails

--- a/docs/org/README.md
+++ b/docs/org/README.md
@@ -31,6 +31,7 @@
   - [Sync Device Serialnumbers To Entraid (Scheduled)](devices/sync-device-serialnumbers-to-entraid_scheduled.md)
 <a name='org-general'></a>
 ## General
+  - [Agent Identities Without Sponsor or Owner (Scheduled)](general/agentidentities-without-owner_scheduled.md)
   - [Add Devices Of Users To Group (Scheduled)](general/add-devices-of-users-to-group_scheduled.md)
   - [Add Management Partner](general/add-management-partner.md)
   - [Add Microsoft Store App Logos](general/add-microsoft-store-app-logos.md)

--- a/docs/org/general/agentidentities-without-owner_scheduled.md
+++ b/docs/org/general/agentidentities-without-owner_scheduled.md
@@ -1,0 +1,73 @@
+# Agent Identities Without Sponsor or Owner (Scheduled)
+
+Report Entra Agent Identities without sponsors or owners.
+
+## Detailed description
+
+This scheduled runbook queries the Microsoft Graph beta API for Entra Agent Identities and reports identities that have no sponsor, no owner, or either relationship. Sponsorless identities are labeled as anomalies because Agent Identities are expected to have at least one sponsor. Ownerless identities are labeled as legitimate because owners are optional.
+
+Sponsor and owner lookup failures are reported as `Unknown (lookup failed)` and are never treated as proof that a relationship is empty. Blueprint details are fetched once and used to enrich each report row.
+
+## Where to find
+
+Org \ General \ Agent Identities Without Sponsor or Owner_Scheduled
+
+## Output
+
+The scheduled job output contains a summary and a table with these fields:
+
+- Status and finding classification
+- Sponsors and owners
+- Blueprint application ID
+- Agent Identity object ID and application ID
+- Agent Identity and Blueprint display names
+- Creation date in UTC
+
+The report does not change tenant data. It does not query audit logs, so it does not attempt to infer the identity creator. Microsoft Entra audit-log retention can prevent reliable creator attribution for older Agent Identities.
+
+## API status
+
+The Agent Identity APIs are currently available only through Microsoft Graph beta endpoints and may change without notice. The runbook uses the derived-type cast paths:
+
+- `/beta/servicePrincipals/microsoft.graph.agentIdentity`
+- `/beta/servicePrincipals/{id}/microsoft.graph.agentIdentity/sponsors`
+- `/beta/servicePrincipals/{id}/microsoft.graph.agentIdentity/owners`
+- `/beta/applications/microsoft.graph.agentIdentityBlueprint`
+
+## Permissions
+
+### Application permissions
+
+- **Type**: Microsoft Graph
+  - AgentIdentity.Read.All
+  - AgentIdentity.ReadWrite.All
+  - AgentIdentityBlueprint.Read.All
+  - Application.Read.All
+  - User.Read.All
+
+`AgentIdentity.ReadWrite.All` is required to list sponsors because Microsoft Graph currently provides no read-only application permission for the sponsors relationship. The runbook itself performs only GET requests.
+
+## Parameters
+
+### ReportScope
+
+Controls which Agent Identities are included in the report.
+
+| Property | Value |
+|----------|-------|
+| Default Value | Missing sponsor or owner |
+| Required | false |
+| Type | String |
+| Allowed Values | Missing sponsor, Missing owner, Missing sponsor or owner, All identities |
+
+### IncludeInactive
+
+Include disabled Agent Identities. By default, only active identities are evaluated.
+
+| Property | Value |
+|----------|-------|
+| Default Value | False |
+| Required | false |
+| Type | Boolean |
+
+[Back to Table of Content](../../../README.md)

--- a/org/general/agentidentities-without-owner_scheduled.permissions.json
+++ b/org/general/agentidentities-without-owner_scheduled.permissions.json
@@ -1,0 +1,33 @@
+{
+    "SchemaVersion": 2,
+    "Permissions": [
+        {
+            "Name": "Microsoft Graph",
+            "Id": "00000003-0000-0000-c000-000000000000",
+            "AppRoleAssignments": [
+                {
+                    "Value": "AgentIdentity.Read.All",
+                    "Reason": "Lists Agent Identities and reads their owners"
+                },
+                {
+                    "Value": "AgentIdentity.ReadWrite.All",
+                    "Reason": "Reads Agent Identity sponsors; Microsoft Graph currently exposes no read-only application permission for this relationship"
+                },
+                {
+                    "Value": "AgentIdentityBlueprint.Read.All",
+                    "Reason": "Reads Agent Identity Blueprints to enrich each identity with its blueprint name and application ID"
+                },
+                {
+                    "Value": "Application.Read.All",
+                    "Reason": "Reads application and service principal details returned for Agent Identities, blueprints, sponsors, and owners"
+                },
+                {
+                    "Value": "User.Read.All",
+                    "Reason": "Reads user display names returned for Agent Identity sponsors and owners"
+                }
+            ]
+        }
+    ],
+    "Roles": [],
+    "ManualPermissions": []
+}

--- a/org/general/agentidentities-without-owner_scheduled.ps1
+++ b/org/general/agentidentities-without-owner_scheduled.ps1
@@ -1,0 +1,317 @@
+<#
+    .SYNOPSIS
+    Report Entra Agent Identities without sponsors or owners
+
+    .DESCRIPTION
+    Lists Entra Agent Identities and reports identities that have no sponsor, no owner, or either,
+    depending on ReportScope. A missing sponsor is labeled as an anomaly because Agent Identities
+    and Agent Identity Blueprints are expected to have at least one sponsor. A missing owner is
+    labeled as legitimate because owners are optional.
+
+    The runbook uses the Microsoft Graph beta API. Sponsor and owner lookup failures are included
+    in the report as unknown findings instead of being treated as an empty relationship.
+
+    .PARAMETER ReportScope
+    Controls which Agent Identities are included: identities missing a sponsor, identities missing
+    an owner, identities missing either relationship, or all identities.
+
+    .PARAMETER IncludeInactive
+    Include disabled Agent Identities. By default, only active identities are evaluated.
+
+    .PARAMETER CallerName
+    Caller name is tracked purely for auditing purposes.
+
+    .INPUTS
+    RunbookCustomization: {
+        "Parameters": {
+            "ReportScope": {
+                "DisplayName": "Report scope",
+                "Select": {
+                    "Options": [
+                        {
+                            "Display": "Missing sponsor or owner",
+                            "ParameterValue": "Missing sponsor or owner"
+                        },
+                        {
+                            "Display": "Missing sponsor",
+                            "ParameterValue": "Missing sponsor"
+                        },
+                        {
+                            "Display": "Missing owner",
+                            "ParameterValue": "Missing owner"
+                        },
+                        {
+                            "Display": "All Agent Identities",
+                            "ParameterValue": "All identities"
+                        }
+                    ],
+                    "ShowValue": false
+                }
+            },
+            "IncludeInactive": {
+                "DisplayName": "Include inactive Agent Identities?",
+                "SelectSimple": {
+                    "Yes - include active and inactive identities": true,
+                    "No - only report active identities": false
+                }
+            },
+            "CallerName": {
+                "Hide": true
+            }
+        }
+    }
+#>
+
+#Requires -Modules @{ModuleName = "RealmJoin.RunbookHelper"; ModuleVersion = "0.8.8" }
+#Requires -Modules @{ModuleName = "Microsoft.Graph.Authentication"; ModuleVersion = "2.39.0" }
+
+param(
+    [ValidateSet('Missing sponsor', 'Missing owner', 'Missing sponsor or owner', 'All identities')]
+    [string]$ReportScope = 'Missing sponsor or owner',
+
+    [bool]$IncludeInactive = $false,
+
+    # CallerName is tracked purely for auditing purposes
+    [Parameter(Mandatory = $true)]
+    [string]$CallerName
+)
+
+########################################################
+#region     RJ Log Part
+########################################################
+
+Write-RjRbLog -Message "Caller: '$CallerName'" -Verbose
+
+$Version = "1.0.0"
+Write-RjRbLog -Message "Version: $Version" -Verbose
+Write-RjRbLog -Message "Submitted parameters:" -Verbose
+Write-RjRbLog -Message "ReportScope: $ReportScope" -Verbose
+Write-RjRbLog -Message "IncludeInactive: $IncludeInactive" -Verbose
+
+#endregion RJ Log Part
+
+########################################################
+#region     Function Definitions
+########################################################
+
+function Get-GraphPagedResult {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Uri
+    )
+
+    $results = [System.Collections.Generic.List[object]]::new()
+    $nextLink = $Uri
+
+    do {
+        $response = Invoke-MgGraphRequest -Method GET -Uri $nextLink -ErrorAction Stop
+        if ($response.value) {
+            $results.AddRange([object[]]$response.value)
+        }
+        $nextLink = $response.'@odata.nextLink'
+    } while ($nextLink)
+
+    return $results.ToArray()
+}
+
+function Get-DirectoryObjectLabel {
+    param(
+        [Parameter(Mandatory = $true)]
+        $DirectoryObject
+    )
+
+    foreach ($propertyName in @('displayName', 'userPrincipalName', 'appId', 'id')) {
+        $value = $DirectoryObject[$propertyName]
+        if (-not [string]::IsNullOrWhiteSpace($value)) {
+            return $value
+        }
+    }
+
+    return 'Unknown directory object'
+}
+
+function Test-InReportScope {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Scope,
+
+        [Parameter(Mandatory = $true)]
+        [bool]$MissingSponsor,
+
+        [Parameter(Mandatory = $true)]
+        [bool]$MissingOwner,
+
+        [Parameter(Mandatory = $true)]
+        [bool]$SponsorLookupFailed,
+
+        [Parameter(Mandatory = $true)]
+        [bool]$OwnerLookupFailed
+    )
+
+    switch ($Scope) {
+        'Missing sponsor' {
+            return $MissingSponsor -or $SponsorLookupFailed
+        }
+        'Missing owner' {
+            return $MissingOwner -or $OwnerLookupFailed
+        }
+        'Missing sponsor or owner' {
+            return $MissingSponsor -or $MissingOwner -or $SponsorLookupFailed -or $OwnerLookupFailed
+        }
+        'All identities' {
+            return $true
+        }
+    }
+}
+
+#endregion Function Definitions
+
+########################################################
+#region     Connect to Microsoft Graph
+########################################################
+
+Write-Output "Connecting to Microsoft Graph..."
+Connect-RjRbGraph
+
+#endregion Connect to Microsoft Graph
+
+########################################################
+#region     Retrieve Agent Identities and Blueprints
+########################################################
+
+$agentIdentityUri = 'https://graph.microsoft.com/beta/servicePrincipals/microsoft.graph.agentIdentity?$select=id,appId,displayName,accountEnabled,createdDateTime,agentIdentityBlueprintId'
+$blueprintUri = 'https://graph.microsoft.com/beta/applications/microsoft.graph.agentIdentityBlueprint?$select=id,appId,displayName'
+
+try {
+    $agentIdentities = @(Get-GraphPagedResult -Uri $agentIdentityUri)
+}
+catch {
+    Write-Error "Failed to list Entra Agent Identities: $($_.Exception.Message)" -ErrorAction Continue
+    throw
+}
+
+$blueprintsById = @{}
+try {
+    $blueprints = @(Get-GraphPagedResult -Uri $blueprintUri)
+    foreach ($blueprint in $blueprints) {
+        $blueprintsById[$blueprint.id] = $blueprint
+    }
+}
+catch {
+    Write-RjRbLog -Message "WARNING: Agent Identity Blueprint enrichment failed: $($_.Exception.Message)" -NoDebugOnly -Verbose
+}
+
+if (-not $IncludeInactive) {
+    $agentIdentities = @($agentIdentities | Where-Object { $_.accountEnabled -eq $true })
+}
+
+Write-Output "Evaluating $($agentIdentities.Count) Agent Identity object(s)..."
+
+#endregion Retrieve Agent Identities and Blueprints
+
+########################################################
+#region     Evaluate Sponsors and Owners
+########################################################
+
+$report = [System.Collections.Generic.List[object]]::new()
+
+foreach ($agentIdentity in $agentIdentities) {
+    $sponsors = @()
+    $owners = @()
+    $sponsorLookupFailed = $false
+    $ownerLookupFailed = $false
+
+    try {
+        $sponsorUri = "https://graph.microsoft.com/beta/servicePrincipals/$($agentIdentity.id)/microsoft.graph.agentIdentity/sponsors?`$select=id,displayName,userPrincipalName,appId"
+        $sponsors = @(Get-GraphPagedResult -Uri $sponsorUri)
+    }
+    catch {
+        $sponsorLookupFailed = $true
+        Write-RjRbLog -Message "WARNING: Sponsor lookup failed for '$($agentIdentity.displayName)' ($($agentIdentity.id)): $($_.Exception.Message)" -NoDebugOnly -Verbose
+    }
+
+    try {
+        $ownerUri = "https://graph.microsoft.com/beta/servicePrincipals/$($agentIdentity.id)/microsoft.graph.agentIdentity/owners?`$select=id,displayName,userPrincipalName,appId"
+        $owners = @(Get-GraphPagedResult -Uri $ownerUri)
+    }
+    catch {
+        $ownerLookupFailed = $true
+        Write-RjRbLog -Message "WARNING: Owner lookup failed for '$($agentIdentity.displayName)' ($($agentIdentity.id)): $($_.Exception.Message)" -NoDebugOnly -Verbose
+    }
+
+    $missingSponsor = -not $sponsorLookupFailed -and $sponsors.Count -eq 0
+    $missingOwner = -not $ownerLookupFailed -and $owners.Count -eq 0
+
+    if (-not (Test-InReportScope -Scope $ReportScope -MissingSponsor $missingSponsor -MissingOwner $missingOwner -SponsorLookupFailed $sponsorLookupFailed -OwnerLookupFailed $ownerLookupFailed)) {
+        continue
+    }
+
+    $findings = [System.Collections.Generic.List[string]]::new()
+    if ($sponsorLookupFailed) {
+        $findings.Add('UNKNOWN: Sponsor lookup failed')
+    }
+    elseif ($missingSponsor) {
+        $findings.Add('ANOMALY: No sponsor')
+    }
+
+    if ($ownerLookupFailed) {
+        $findings.Add('UNKNOWN: Owner lookup failed')
+    }
+    elseif ($missingOwner) {
+        $findings.Add('Ownerless (legitimate)')
+    }
+
+    if ($findings.Count -eq 0) {
+        $findings.Add('No finding')
+    }
+
+    $blueprint = $blueprintsById[$agentIdentity.agentIdentityBlueprintId]
+    $createdOn = if ($agentIdentity.createdDateTime) {
+        ([datetime]$agentIdentity.createdDateTime).ToUniversalTime().ToString('yyyy-MM-dd HH:mm:ss')
+    }
+    else {
+        'Unknown'
+    }
+
+    $report.Add([PSCustomObject]@{
+        Status             = if ($agentIdentity.accountEnabled) { 'Active' } else { 'Inactive' }
+        Finding            = $findings -join '; '
+        Sponsors           = if ($sponsorLookupFailed) { 'Unknown (lookup failed)' } elseif ($sponsors.Count -eq 0) { '-' } else { ($sponsors | ForEach-Object { Get-DirectoryObjectLabel -DirectoryObject $_ }) -join '; ' }
+        Owners             = if ($ownerLookupFailed) { 'Unknown (lookup failed)' } elseif ($owners.Count -eq 0) { '-' } else { ($owners | ForEach-Object { Get-DirectoryObjectLabel -DirectoryObject $_ }) -join '; ' }
+        BlueprintAppId     = if ($blueprint) { $blueprint.appId } elseif ($agentIdentity.agentIdentityBlueprintId) { $agentIdentity.agentIdentityBlueprintId } else { 'Unknown' }
+        ObjectId           = $agentIdentity.id
+        AppId              = $agentIdentity.appId
+        AgentIdentity      = $agentIdentity.displayName
+        AgentBlueprint     = if ($blueprint) { $blueprint.displayName } else { 'Unknown' }
+        CreatedOnUtc       = $createdOn
+    })
+}
+
+#endregion Evaluate Sponsors and Owners
+
+########################################################
+#region     Report Results
+########################################################
+
+$sortedReport = @($report | Sort-Object Finding, AgentIdentity)
+$sponsorlessCount = @($sortedReport | Where-Object { $_.Finding -like '*ANOMALY: No sponsor*' }).Count
+$ownerlessCount = @($sortedReport | Where-Object { $_.Finding -like '*Ownerless (legitimate)*' }).Count
+$lookupFailureCount = @($sortedReport | Where-Object { $_.Finding -like '*UNKNOWN:*' }).Count
+
+Write-Output ""
+Write-Output "## Entra Agent Identity sponsor and owner report"
+Write-Output "Scope: $ReportScope"
+Write-Output "Reported identities: $($sortedReport.Count)"
+Write-Output "Sponsorless anomalies: $sponsorlessCount"
+Write-Output "Ownerless identities (legitimate): $ownerlessCount"
+Write-Output "Identities with lookup failures: $lookupFailureCount"
+Write-Output ""
+
+if ($sortedReport.Count -eq 0) {
+    Write-Output "No Agent Identities matched the selected report scope."
+}
+else {
+    $sortedReport | Format-List Status, Finding, Sponsors, Owners, BlueprintAppId, ObjectId, AppId, AgentIdentity, AgentBlueprint, CreatedOnUtc
+}
+
+#endregion Report Results


### PR DESCRIPTION
This pull request introduces a new scheduled runbook for reporting Entra Agent Identities that lack sponsors or owners. The runbook leverages Microsoft Graph beta APIs to identify and classify such identities, enriches the report with additional details, and provides flexible reporting options. The update includes documentation, permissions, and the implementation script.

**New Runbook: Agent Identities Without Sponsor or Owner (Scheduled)**

*Runbook implementation and logic:*
- Adds `agentidentities-without-owner_scheduled.ps1` to enumerate Entra Agent Identities, check for missing sponsors/owners, classify findings, and output a detailed report. Lookup failures are surfaced as "unknown" rather than false negatives, and blueprint enrichment is included. The script supports filtering by report scope and optionally includes inactive identities.

*Documentation:*
- Adds a comprehensive markdown doc describing the runbook’s purpose, API usage, permissions, parameters, and output fields (`agentidentities-without-owner_scheduled.md`).
- Updates the Org/General section in the runbook documentation index to include the new runbook.
- Updates the changelog to announce the addition and summarize the runbook’s features and requirements.

*Permissions:*
- Introduces a permissions manifest specifying required Microsoft Graph application permissions, including `AgentIdentity.ReadWrite.All` (needed for sponsor relationship queries due to Graph API limitations), as well as permissions for blueprints, applications, and users.